### PR TITLE
Add `#ueor`, remove unescaping from `#or`

### DIFF
--- a/ParserPower.i18n.magic.php
+++ b/ParserPower.i18n.magic.php
@@ -17,6 +17,7 @@ $magicWords['en'] = [
 	'trimuesc'            => [0, 'trimuesc'],
 	'ueif'                => [0, 'ueif'],
 	'or'                  => [0, 'or'],
+	'ueor'                => [0, 'ueor'],
 	'ueifeq'              => [0, 'ueifeq'],
 	'token'               => [0, 'token'],
 	'tokenif'             => [0, 'tokenif'],

--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -75,6 +75,11 @@ class ParserPowerSimple {
 			Parser::SFH_OBJECT_ARGS
 		);
 		$parser->setFunctionHook(
+			'ueor',
+			'ParserPower\\ParserPowerSimple::ueorRender',
+			Parser::SFH_OBJECT_ARGS
+		);
+		$parser->setFunctionHook(
 			'ueifeq',
 			'ParserPower\\ParserPowerSimple::ueifeqRender',
 			Parser::SFH_OBJECT_ARGS
@@ -307,6 +312,28 @@ class ParserPowerSimple {
 	 * @return array The function output along with relevant parser options.
 	 */
 	public static function orRender($parser, $frame, $params) {
+		foreach ($params as $param) {
+			$inValue = trim($frame->expand($param));
+
+			if ($inValue !== '') {
+				return [$inValue, 'noparse' => false];
+			}
+		}
+
+		return ['', 'noparse' => false];
+	}
+
+	/**
+	 * This function performs the test for the ueor function.
+	 *
+	 * @param Parser  $parser The parser object. Ignored.
+	 * @param PPFrame $frame  The parser frame object.
+	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
+	 *
+	 * @return array The function output along with relevant parser options.
+	 */
+	public static function ueorRender($parser, $frame, $params) {
+
 		foreach ($params as $param) {
 			$inValue = trim($frame->expand($param));
 


### PR DESCRIPTION
## Context

As presented in the [extension documentation](https://help.fandom.com/wiki/Extension:ParserPower/Escape_sequences#Delaying_template_or_parser_function_processing), escape sequences (and associated `<esc>` tags) allow to delay wikitext parsing.

The original _ParserFunctions_ functions do not unescape their parameters (and return value), so this extension adds variations of these functions to do this additional step. These are called (and supposed to work) the same way, with an `ue` prefix (i.e. `#ueif`, `#ueifeq` and `#ueswitch`).

This extension also adds a `#or` parser function, which is supposed to be a variant of the `#if` parser function. On top of the traditional `#if` operations, it also unescapes its parameters.

## Motivation

The name of the `#or` parser function, when mixed with other _ParserFunctions_ functions, does not directly suggest that escaping is performed.

In the case where escaping is not desired, this extension does not provide an alternative to using the `#if` parser function.

## Proposed Changes

* rename `#or` to `#ueor`,
* add a new `#or` parser function which does not unescape.

## Examples

Current behavior:

```html
<esc>|</esc>                            <!-- renders  \!  -->

{{#if:   <esc>|</esc> | <esc>|</esc> }} <!-- renders  \!  -->
{{#or:   <esc>|</esc> }}                <!-- renders  |   -->

{{#ueif: <esc>|</esc> | <esc>|</esc> }} <!-- renders  |   -->
```

Proposed behavior:

```html
<esc>|</esc>                            <!-- renders  \!  -->

{{#if:   <esc>|</esc> | <esc>|</esc> }} <!-- renders  \!  -->
{{#or:   <esc>|</esc> }}                <!-- renders  \!  -->

{{#ueif: <esc>|</esc> | <esc>|</esc> }} <!-- renders  |   -->
{{#ueor: <esc>|</esc> }}                <!-- renders  |   -->
```