### PR TITLE
`#listmerge`: Trim `token1`/`token2` parameters

### DIFF
--- a/includes/ParserPowerLists.php
+++ b/includes/ParserPowerLists.php
@@ -2383,8 +2383,8 @@ class ParserPowerLists {
 			}
 
 			if ($tokenSep !== '') {
-				$tokens1 = explode($tokenSep, $token1);
-				$tokens2 = explode($tokenSep, $token2);
+				$tokens1 = array_map('trim', explode($tokenSep, $token1));
+				$tokens2 = array_map('trim', explode($tokenSep, $token2));
 			} else {
 				$tokens1 = [$token1];
 				$tokens2 = [$token2];


### PR DESCRIPTION
## Motivation

[A (previously merged) PR](https://gitlab.com/hydrawiki/extensions/ParserPower/-/merge_requests/5) allowed additional spacing before and after parameters, and between list elements. For example, the list ` a, b` would be parsed as [`a`, `b`] (using `,` as input separator), not as [` a`, ` b`].

However, if multiple tokens are given (to functions allowing the use of multiple tokens), spaces between tokens are not removed. [For example](https://bindingofisaacrebirth.fandom.com/wiki/User:Derugon/Sandbox/List/Pattern_trimming_2), the following wikitext merges list elements having the same key (as `<key1>:<value1>, <key2>:<value2>, …`), concatenating the two values:
```html
{{#listmerge:
 | list         = a:1, b:1, a:2, c:1, b:2, a:3, a:4
 | token1       = @fst,@snd
 | token2       = $fst,$snd
 | fieldsep     = :
 | matchpattern = <esc>{{#ifeq: @fst | $fst | yes }}</esc>
 | mergepattern = @fst:@snd$snd
}}
```
This wikitext is then parsed as `a:1234, b:12, c:1`.

But if we add additional spaces between the sub-tokens, we no longer get the expected result. For example, using `@fst, @snd` as `token1` would give the `@fst` and ` @snd` sub-tokens, then `mergepattern` would not recognize the `@snd` parameter. Consequently, the result of the parser function would be `a:@snd4, b:@snd2, c:1`.

## Proposed Changes

Trim values of `token1` and `token2` once split.