### PR TITLE
`#ueif`/`#ueifeq`: Trim out values

### DIFF
--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -292,14 +292,14 @@ class ParserPowerSimple {
 	 */
 	public static function ueifRender($parser, $frame, $params) {
 		$condition = isset($params[0]) ? trim($frame->expand($params[0])) : '';
-		$trueValue = isset($params[1]) ? $params[1] : '';
-		$falseValue = isset($params[2]) ? $params[2] : '';
 
 		if ($condition !== '') {
-			return [ParserPower::unescape($frame->expand($trueValue)), 'noparse' => false];
+			$value = isset($params[1]) ? $params[1] : '';
 		} else {
-			return [ParserPower::unescape($frame->expand($falseValue)), 'noparse' => false];
+			$value = isset($params[2]) ? $params[2] : '';
 		}
+
+		return [ ParserPower::unescape(trim($frame->expand($value))), 'noparse' => false ];
 	}
 
 	/**
@@ -357,14 +357,14 @@ class ParserPowerSimple {
 	public static function ueifeqRender($parser, $frame, $params) {
 		$leftValue = isset($params[0]) ? ParserPower::unescape(trim($frame->expand($params[0]))) : '';
 		$rightValue = isset($params[1]) ? ParserPower::unescape(trim($frame->expand($params[1]))) : '';
-		$trueValue = isset($params[2]) ? $params[2] : '';
-		$falseValue = isset($params[3]) ? $params[3] : '';
 
 		if ($leftValue === $rightValue) {
-			return [ParserPower::unescape($frame->expand($trueValue)), 'noparse' => false];
+			$value = isset($params[2]) ? $params[2] : '';
 		} else {
-			return [ParserPower::unescape($frame->expand($falseValue)), 'noparse' => false];
+			$value = isset($params[3]) ? $params[3] : '';
 		}
+
+		return [ ParserPower::unescape(trim($frame->expand($value))), 'noparse' => false ];
 	}
 
 	/**


### PR DESCRIPTION
## Motivation

The `#if` and `#ifeq` functions ignore spaces before and after all of their parameters. However, the `#ueif` and `#ueifeq` functions do not work the same way, by only trimming their condition parameter, not true/false values.
For example:

```html
"{{#if:     | 1 | 0 }}"  <!-- yields "0"   -->
"{{#if:   a | 1 | 0 }}"  <!-- yields "1"   -->
"{{#ueif:   | 1 | 0 }}"  <!-- yields " 0 " -->
"{{#ueif: a | 1 | 0 }}"  <!-- yields " 1 " -->
```

Since these functions unescape their parameters, the same behavior can be achieved by explicitely adding escaped spaces (`\_`) before/after value parameters.

## Proposed changes

Make `#ueif` and `#ueifeq` trim their true/false value parameters before escaping (as `#ueswitch` and similar functions do):
```html
"{{#ueif:   |   1   |   0   }}"  <!-- would yield "0" -->
"{{#ueif: a |   1   |   0   }}"  <!-- would yield "1" -->
"{{#ueif:   | \_1\_ | \_0\_ }}"  <!-- would yield " 0 " -->
"{{#ueif: a | \_1\_ | \_0\_ }}"  <!-- would yield " 1 " -->
```