### PR TITLE
`#ueswitch`: Trim case key for comparison

### DIFF
--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -430,12 +430,12 @@ class ParserPowerSimple {
 
 			$keyFound = false;
 			foreach ($params as $param) {
-				$pair = explode('=', trim($frame->expand($param)), 2);
-				if (!$keyFound && ParserPower::unescape($pair[0]) === $switchKey) {
+				$pair = explode('=', $frame->expand($param), 2);
+				if (!$keyFound && ParserPower::unescape(trim($pair[0])) === $switchKey) {
 					$keyFound = true;
 				}
 				if ($keyFound && count($pair) > 1) {
-					return [ParserPower::unescape(trim($frame->expand($pair[1]))), 'noparse' => false];
+					return [ParserPower::unescape(trim($pair[1])), 'noparse' => false];
 				}
 			}
 			return [ParserPower::unescape(trim($frame->expand($default))), 'noparse' => false];


### PR DESCRIPTION
## Motivation

Let `X = Y` be a switch case (with `X` and `Y` arbitrary wikitext expressions):
- the `#switch` function trims `X` before comparing it to the base value, then maybe return `Y` (trimmed).
- the `#ueswitch` function trims `X = Y` before splitting it and comparing `X` to the base value, then maybe return `Y` (trimmed).

Consequently, any space between `X` and `=` is ignored by `#switch` but not by `#ueswitch`.
For example:

```html
{{#switch:   1 | 1= OK | ko }}  <!-- yields OK -->
{{#switch:   1 | 1 = OK | ko }} <!-- yields OK -->
{{#ueswitch: 1 | 1= OK | ko }}  <!-- yields OK -->
{{#ueswitch: 1 | 1 = OK | ko }} <!-- yields ko -->
```

## Proposed changes

Change the `#ueswitch` parsing order of a case `X = Y`
- from (1) trimming `X = Y` then (2) splitting it into `X` and `Y`,
- to (1) splitting `X = Y` into `X` and `Y` then (2) trimming both of these.