### PR TITLE
`#ueswitch`: Recognize `#default` magic word

### DIFF
--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -437,7 +437,7 @@ class ParserPowerSimple {
 					$key = ParserPower::unescape($pair[0]);
 					if ($key === $switchKey) {
 						$keyFound = true;
-					} else if ($mwDefault->matchStartToEnd($key)) {
+					} elseif ($mwDefault->matchStartToEnd($key)) {
 						$mwDefaultFound = true;
 					}
 				}
@@ -445,7 +445,7 @@ class ParserPowerSimple {
 				if (count($pair) > 1) {
 					if ($keyFound) {
 						return [ParserPower::unescape(trim($frame->expand($pair[1]))), 'noparse' => false];
-					} else if ($mwDefaultFound) {
+					} elseif ($mwDefaultFound) {
 						$default = $pair[1];
 						$mwDefaultFound = false;
 					}

--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -447,6 +447,7 @@ class ParserPowerSimple {
 						return [ParserPower::unescape(trim($frame->expand($pair[1]))), 'noparse' => false];
 					} else if ($mwDefaultFound) {
 						$default = $pair[1];
+						$mwDefaultFound = false;
 					}
 				}
 			}


### PR DESCRIPTION
## Motivation

The `#switch` parser function accepts a default case, whose value is returned if no other case matched the base value.

The default value is either:
1. The last case value, if it has no key specified, or
2. The last case with the `#default` key.

For example, all parser functions below yield `X`:
```html
{{#switch:c|a=1|b=2|3|X}}
{{#switch:c|a=1|#default=2|#default=X|b=3}}
{{#switch:c|a=1|#default=2|b=3|X}}
```

The `#ueswitch` parser function accepts a default case, which can only be specified with an additional last case without key (the rule 1. above).

## Proposed changes

Make the `#ueswitch` parser function detect default cases the same way as the `#switch` one, by recognizing the `#default` magic word in case keys and updating the default value acordingly.

These changes are written to not break existing code as much as I could, i.e.:
- All parameters that were expanded / were not expanded are still expanded the same way,
- Matching the text `#default` with case keys still works as expected: the earliest case with a `#default` key is used, otherwise the default value is used (by only using the last-case-with-no-key rule). For example, all parser functions below yield `X`:
```html
{{#ueswitch:#default|a=1|#default=X|b=2|3}}
{{#ueswitch:#default|a=1|b=2|X}}
```