### PR TITLE
Doc fixes and cleanup

### DIFF
--- a/includes/ParserPower.php
+++ b/includes/ParserPower.php
@@ -264,7 +264,7 @@ class ParserPower {
 	 * @param string  $token      The token to replace.
 	 * @param string  $pattern    Pattern containing token to be replaced with the input value.
 	 *
-	 * @return The result of the token replacement within the pattern.
+	 * @return string The result of the token replacement within the pattern.
 	 */
 	public static function applyPatternWithIndex($parser, $frame, $inValue, $indexToken, $index, $token, $pattern) {
 		$inValue = trim($inValue);

--- a/includes/ParserPowerLists.php
+++ b/includes/ParserPowerLists.php
@@ -95,111 +95,27 @@ class ParserPowerLists {
 	 * @return void
 	 */
 	public static function setup(&$parser) {
-		$parser->setFunctionHook(
-			'lstcnt',
-			'ParserPower\\ParserPowerLists::lstcntRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstsep',
-			'ParserPower\\ParserPowerLists::lstsepRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstelem',
-			'ParserPower\\ParserPowerLists::lstelemRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstsub',
-			'ParserPower\\ParserPowerLists::lstsubRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstfnd',
-			'ParserPower\\ParserPowerLists::lstfndRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstind',
-			'ParserPower\\ParserPowerLists::lstindRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstapp',
-			'ParserPower\\ParserPowerLists::lstappRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstprep',
-			'ParserPower\\ParserPowerLists::lstprepRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstjoin',
-			'ParserPower\\ParserPowerLists::lstjoinRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstcntuniq',
-			'ParserPower\\ParserPowerLists::lstcntuniqRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'listunique',
-			'ParserPower\\ParserPowerLists::listuniqueRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstuniq',
-			'ParserPower\\ParserPowerLists::lstuniqRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'listfilter',
-			'ParserPower\\ParserPowerLists::listfilterRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstfltr',
-			'ParserPower\\ParserPowerLists::lstfltrRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstrm',
-			'ParserPower\\ParserPowerLists::lstrmRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'listsort',
-			'ParserPower\\ParserPowerLists::listsortRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstsrt',
-			'ParserPower\\ParserPowerLists::lstsrtRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'listmap',
-			'ParserPower\\ParserPowerLists::listmapRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstmap',
-			'ParserPower\\ParserPowerLists::lstmapRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'lstmaptemp',
-			'ParserPower\\ParserPowerLists::lstmaptempRender',
-			SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'listmerge',
-			'ParserPower\\ParserPowerLists::listmergeRender',
-			SFH_OBJECT_ARGS
-		);
+		$parser->setFunctionHook('lstcnt', [ __CLASS__, 'lstcntRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstsep', [ __CLASS__, 'lstsepRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstelem', [ __CLASS__, 'lstelemRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstsub', [ __CLASS__, 'lstsubRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstfnd', [ __CLASS__, 'lstfndRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstind', [ __CLASS__, 'lstindRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstapp', [ __CLASS__, 'lstappRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstprep', [ __CLASS__, 'lstprepRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstjoin', [ __CLASS__, 'lstjoinRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstcntuniq', [ __CLASS__, 'lstcntuniqRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('listunique', [ __CLASS__, 'listuniqueRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstuniq', [ __CLASS__, 'lstuniqRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('listfilter', [ __CLASS__, 'listfilterRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstfltr', [ __CLASS__, 'lstfltrRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstrm', [ __CLASS__, 'lstrmRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('listsort', [ __CLASS__, 'listsortRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstsrt', [ __CLASS__, 'lstsrtRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('listmap', [ __CLASS__, 'listmapRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstmap', [ __CLASS__, 'lstmapRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('lstmaptemp', [ __CLASS__, 'lstmaptempRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('listmerge', [ __CLASS__, 'listmergeRender' ], Parser::SFH_OBJECT_ARGS);
 	}
 
 	/**
@@ -1517,7 +1433,7 @@ class ParserPowerLists {
 				}
 			} else {
 				if ($options & self::SORT_DESC) {
-					usort($values, 'ParserPower\\ParserPowerCompare::rstrcasecmp');
+					usort($values, [ ParserPowerCompare::class, 'rstrcasecmp' ]);
 					return $values;
 				} else {
 					usort($values, 'strcasecmp');
@@ -2396,7 +2312,7 @@ class ParserPowerLists {
 				$parser,
 				$frame,
 				$inValues,
-				'ParserPower\\ParserPowerLists::applyTwoSetFieldPattern',
+				[ __CLASS__, 'applyTwoSetFieldPattern' ],
 				$matchParams,
 				$mergeParams,
 				2,
@@ -2471,7 +2387,7 @@ class ParserPowerLists {
 				$parser,
 				$frame,
 				$inValues,
-				'ParserPower\\ParserPowerLists::applyTemplateToTwoValues',
+				[ __CLASS__, 'applyTemplateToTwoValues' ],
 				$matchParams,
 				$mergeParams,
 				2,

--- a/includes/ParserPowerLists.php
+++ b/includes/ParserPowerLists.php
@@ -265,7 +265,7 @@ class ParserPowerLists {
 	 * according to specified offset and length. It also performs un-escaping on each item. Note that values
 	 * that are only empty after the unescape are preserved.
 	 *
-	 * @param array $inOffset
+	 * @param int   $inOffset
 	 * @param int   $inLength
 	 * @param array $inValues The array to trim, remove empty values from, slice, and unescape.
 	 *
@@ -329,7 +329,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the counting operation for the lstcnt function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -354,7 +354,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the delimiter replacement operation for the lstsep function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -380,7 +380,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the list element retrieval operation for the lstelem function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -412,7 +412,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the list subdivision and delimiter replacement operation for the lstsub function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -455,7 +455,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the search operation for the lstfnd function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -495,7 +495,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the search operation for the lstind function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -561,7 +561,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the append operation for the lstapp function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -590,7 +590,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the prepend operation for the lstprep function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -619,7 +619,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the joining operation for the lstjoin function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -667,7 +667,7 @@ class ParserPowerLists {
 	 * @param string  $token   The token to replace.
 	 * @param string  $pattern Pattern containing token to be replaced with the input value.
 	 *
-	 * @return The result of the token replacement within the pattern.
+	 * @return string The result of the token replacement within the pattern.
 	 */
 	private static function applyPattern($parser, $frame, $inValue, $token, $pattern) {
 		return ParserPower::applyPattern($parser, $frame, $inValue, $token, $pattern);
@@ -685,7 +685,7 @@ class ParserPowerLists {
 	 * @param string  $token      The token to replace.
 	 * @param string  $pattern    Pattern containing token to be replaced with the input value.
 	 *
-	 * @return The result of the token replacement within the pattern.
+	 * @return string The result of the token replacement within the pattern.
 	 */
 	private static function applyPatternWithIndex($parser, $frame, $inValue, $indexToken, $index, $token, $pattern) {
 		return ParserPower::applyPatternWithIndex($parser, $frame, $inValue, $indexToken, $index, $token, $pattern);
@@ -702,7 +702,7 @@ class ParserPowerLists {
 	 * @param int     $tokenCount The number of tokens.
 	 * @param string  $pattern    Pattern containing tokens to be replaced by field values.
 	 *
-	 * @return The result of the token replacement within the pattern.
+	 * @return string The result of the token replacement within the pattern.
 	 */
 	private static function applyFieldPattern(
 		$parser,
@@ -730,7 +730,7 @@ class ParserPowerLists {
 	 * @param int     $tokenCount The number of tokens.
 	 * @param string  $pattern    Pattern containing tokens to be replaced by field values.
 	 *
-	 * @return The result of the token replacement within the pattern.
+	 * @return string The result of the token replacement within the pattern.
 	 */
 	private static function applyFieldPatternWithIndex(
 		$parser,
@@ -786,7 +786,7 @@ class ParserPowerLists {
 	 * @param string  $template The template to pass the parameters to.
 	 * @param string  $fieldSep The delimiter separating the parameter values.
 	 *
-	 * @return The result of the template.
+	 * @return string The result of the template.
 	 */
 	private static function applyTemplate($parser, $frame, $inValue, $template, $fieldSep) {
 		$inValue = trim($inValue);
@@ -1183,7 +1183,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the counting operation for the lstcntuniq function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -1424,7 +1424,7 @@ class ParserPowerLists {
 	/**
 	 * This function directs the duplicate removal function for the lstuniq function.
 	 *
-	 * @param Parser  $parser The parser object. Ignored.
+	 * @param Parser  $parser The parser object.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -1925,12 +1925,12 @@ class ParserPowerLists {
 				}
 			}
 
-			if ($duplicates == 'strip' || $duplicates == 'poststrip' || $duplicates == 'pre/postsort') {
+			if ($duplicates === 'strip' || $duplicates === 'poststrip' || $duplicates === 'pre/postsort') {
 				$outValues = array_unique($outValues);
 			}
 
 			if (($indexToken === '' && $sortMode === 'sort')
-				|| $sortMode == 'postsort' || $sortMode == 'pre/postsort'
+				|| $sortMode === 'postsort' || $sortMode === 'pre/postsort'
 			) {
 				$outValues = self::sortList($outValues, $sortOptions);
 			}
@@ -1990,11 +1990,11 @@ class ParserPowerLists {
 			$inSep = $parser->getStripState()->unstripNoWiki($inSep);
 
 			$inValues = self::arrayTrimUnescape(self::explodeList($inSep, $inList));
-			if ($duplicates == 'prestrip' || $duplicates == 'pre/postsort') {
+			if ($duplicates === 'prestrip' || $duplicates === 'pre/postsort') {
 				$inValues = array_unique($inValues);
 			}
 
-			if ($sortMode == 'presort' || $sortMode == 'pre/postsort') {
+			if ($sortMode === 'presort' || $sortMode === 'pre/postsort') {
 				$inValues = self::sortList($inValues, $sortOptions);
 			}
 
@@ -2003,11 +2003,11 @@ class ParserPowerLists {
 				$outValues[] = self::applyTemplate($parser, $frame, $inValue, $template, $fieldSep);
 			}
 
-			if ($sortMode == 'sort' || $sortMode == 'postsort' || $sortMode == 'pre/postsort') {
+			if ($sortMode === 'sort' || $sortMode === 'postsort' || $sortMode === 'pre/postsort') {
 				$outValues = self::sortList($outValues, $sortOptions);
 			}
 
-			if ($duplicates == 'strip' || $duplicates == 'poststrip' || $duplicates == 'pre/postsort') {
+			if ($duplicates === 'strip' || $duplicates === 'poststrip' || $duplicates === 'pre/postsort') {
 				$outValues = array_unique($outValues);
 			}
 
@@ -2378,7 +2378,7 @@ class ParserPowerLists {
 
 			$inValues = self::arrayTrimUnescape(self::explodeList($inSep, $inList));
 
-			if ($sortMode == 'presort' || $sortMode == 'pre/postsort') {
+			if ($sortMode === 'presort' || $sortMode === 'pre/postsort') {
 				$inValues = self::sortList($inValues, $sortOptions);
 			}
 
@@ -2403,7 +2403,7 @@ class ParserPowerLists {
 				3
 			);
 
-			if ($sortMode == 'sort' || $sortMode == 'postsort' || $sortMode == 'pre/postsort') {
+			if ($sortMode === 'sort' || $sortMode === 'postsort' || $sortMode === 'pre/postsort') {
 				$outValues = self::sortList($outValues, $sortOptions);
 			}
 
@@ -2461,7 +2461,7 @@ class ParserPowerLists {
 
 			$inValues = self::arrayTrimUnescape(self::explodeList($inSep, $inList));
 
-			if ($sortMode == 'presort' || $sortMode == 'pre/postsort') {
+			if ($sortMode === 'presort' || $sortMode === 'pre/postsort') {
 				$inValues = self::sortList($inValues, $sortOptions);
 			}
 

--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -26,96 +26,31 @@ class ParserPowerSimple {
 	 * @return void
 	 */
 	public static function setup(&$parser) {
-		$parser->setFunctionHook(
-			'trim',
-			'ParserPower\\ParserPowerSimple::trimRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'uesc',
-			'ParserPower\\ParserPowerSimple::uescRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'uescnowiki',
-			'ParserPower\\ParserPowerSimple::uescnowikiRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'trimuesc',
-			'ParserPower\\ParserPowerSimple::trimuescRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setHook(
-			'linkpage',
-			'ParserPower\\ParserPowerSimple::linkpageRender'
-		);
-		$parser->setHook(
-			'linktext',
-			'ParserPower\\ParserPowerSimple::linktextRender'
-		);
-		$parser->setHook(
-			'esc',
-			'ParserPower\\ParserPowerSimple::escRender'
-		);
+		$parser->setFunctionHook('trim', [ __CLASS__, 'trimRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('uesc', [ __CLASS__, 'uescRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('uescnowiki', [ __CLASS__, 'uescnowikiRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('trimuesc', [ __CLASS__, 'trimuescRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setHook('linkpage', [ __CLASS__, 'linkpageRender' ]);
+		$parser->setHook('linktext', [ __CLASS__, 'linktextRender' ]);
+		$parser->setHook('esc', [ __CLASS__, 'escRender' ]);
 		for ($i = 1; $i < 10; ++$i) {
-			$parser->setHook(
-				'esc' . $i,
-				'ParserPower\\ParserPowerSimple::escRender'
-			);
+			$parser->setHook('esc' . $i, [ __CLASS__, 'escRender' ]);
 		}
-		$parser->setFunctionHook(
-			'ueif',
-			'ParserPower\\ParserPowerSimple::ueifRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'or',
-			'ParserPower\\ParserPowerSimple::orRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'ueor',
-			'ParserPower\\ParserPowerSimple::ueorRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'ueifeq',
-			'ParserPower\\ParserPowerSimple::ueifeqRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'token',
-			'ParserPower\\ParserPowerSimple::tokenRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'tokenif',
-			'ParserPower\\ParserPowerSimple::tokenifRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'ueswitch',
-			'ParserPower\\ParserPowerSimple::ueswitchRender',
-			Parser::SFH_OBJECT_ARGS
-		);
-		$parser->setFunctionHook(
-			'follow',
-			'ParserPower\\ParserPowerSimple::followRender',
-			Parser::SFH_OBJECT_ARGS
-		);
+		$parser->setFunctionHook('ueif', [ __CLASS__, 'ueifRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('or', [ __CLASS__, 'orRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('ueor', [ __CLASS__, 'ueorRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('ueifeq', [ __CLASS__, 'ueifeqRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('token', [ __CLASS__, 'tokenRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('tokenif', [ __CLASS__, 'tokenifRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('ueswitch', [ __CLASS__, 'ueswitchRender' ], Parser::SFH_OBJECT_ARGS);
+		$parser->setFunctionHook('follow', [ __CLASS__, 'followRender' ], Parser::SFH_OBJECT_ARGS);
 		
-		if ( defined( 'PF_VERSION' ) ) {
-			// Do not load if Page Forms is installed.
-			return;
+		// Do not load if Page Forms is installed.
+		if ( !defined( 'PF_VERSION' ) ) {
+			$parser->setFunctionHook( 'arraymap', [ __CLASS__, 'arraymapRender' ], Parser::SFH_OBJECT_ARGS );
+			$parser->setFunctionHook( 'arraymaptemplate', [ __CLASS__, 'arraymaptemplateRender' ],
+				Parser::SFH_OBJECT_ARGS );
 		}
-		
-		$parser->setFunctionHook( 'arraymap', 'ParserPower\\ParserPowerSimple::arraymapRender',
-			Parser::SFH_OBJECT_ARGS );
-
-		$parser->setFunctionHook( 'arraymaptemplate', 'ParserPower\\ParserPowerSimple::arraymaptemplateRender',
-			Parser::SFH_OBJECT_ARGS );
-		
 	}
 
 	/**

--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -13,7 +13,7 @@ namespace ParserPower;
 
 use MediaWiki\MediaWikiServices;
 use PPFrame;
-use Title;
+use MediaWiki\Title\Title;
 use Parser;
 use PPNode_Hash_Array;
 

--- a/includes/ParserPowerSimple.php
+++ b/includes/ParserPowerSimple.php
@@ -137,9 +137,9 @@ class ParserPowerSimple {
 	 * This function performs the unescape operation for the uesc parser function. This trims the value first, leaving
 	 * whitespace intact if it's there after escape sequences are replaced.
 	 *
-	 * @param Parser  $parser The parser object.
+	 * @param Parser  $parser The parser object. Ignored.
 	 * @param PPFrame $frame  The parser frame object.
-	 * @param array   $params Attributes values of the tag function.
+	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
 	 * @return array The function output along with relevant parser options.
 	 */
@@ -154,9 +154,9 @@ class ParserPowerSimple {
 	 * leaving whitespace intact if it's there after escape sequences are replaced. It returns the content wrapped in
 	 * <nowiki> tags so that it isn't parsed.
 	 *
-	 * @param Parser  $parser The parser object.
+	 * @param Parser  $parser The parser object. Ignored.
 	 * @param PPFrame $frame  The parser frame object.
-	 * @param array   $params Attributes values of the tag function.
+	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
 	 * @return array The function output along with relevant parser options.
 	 */
@@ -189,10 +189,10 @@ class ParserPowerSimple {
 	 * This removes internal links from, the given wikicode, replacing them with
 	 * the name of the page they would have linked to.
 	 *
+	 * @param string  $text    The text within the tag function.
+	 * @param array   $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser  $parser  The parser object.
 	 * @param PPFrame $frame   The parser frame object.
-	 * @param string  $text    The text within the tag function.
-	 * @param array   $attribs Attributes values of the tag function.
 	 *
 	 * @return array The function output along with relevant parser options.
 	 */
@@ -215,7 +215,7 @@ class ParserPowerSimple {
 	 *
 	 * @param array $matches The parameters and values together, not yet exploded or trimmed.
 	 *
-	 * @return array The function output along with relevant parser options.
+	 * @return string The function output along with relevant parser options.
 	 */
 	public static function linkpageReplace($matches) {
 		$parts = explode('|', $matches[1], 2);
@@ -227,10 +227,10 @@ class ParserPowerSimple {
 	 * This removes internal links from, the given wikicode, replacing them with
 	 * the text that any links would return.
 	 *
-	 * @param Parser  $parser  The parser object. Ignored.
+	 * @param string  $text    The text within the tag function.
+	 * @param array   $attribs Attributes values of the tag function. Ignored.
+	 * @param Parser  $parser  The parser object.
 	 * @param PPFrame $frame   The parser frame object.
-	 * @param string  $text    The parameters and values together, not yet exploded or trimmed.
-	 * @param array   $attribs
 	 *
 	 * @return array The function output along with relevant parser options.
 	 */
@@ -266,10 +266,10 @@ class ParserPowerSimple {
 	/**
 	 * This function escapes all appropriate characters in the given text and returns the result.
 	 *
+	 * @param string  $text    The text within the tag function.
+	 * @param array   $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser  $parser  The parser object.
 	 * @param PPFrame $frame   The parser frame object.
-	 * @param string  $text    The text within the tag function.
-	 * @param array   $attribs Attributes values of the tag function.
 	 *
 	 * @return array The function output along with relevant parser options.
 	 */
@@ -284,7 +284,7 @@ class ParserPowerSimple {
 	/**
 	 * This function performs the test for the ueif function.
 	 *
-	 * @param Parser  $parser The parser object.
+	 * @param Parser  $parser The parser object. Ignored.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -305,7 +305,7 @@ class ParserPowerSimple {
 	/**
 	 * This function performs the test for the or function.
 	 *
-	 * @param Parser  $parser The parser object.
+	 * @param Parser  $parser The parser object. Ignored.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -348,7 +348,7 @@ class ParserPowerSimple {
 	/**
 	 * This function performs the test for the ueifeq function.
 	 *
-	 * @param Parser  $parser The parser object.
+	 * @param Parser  $parser The parser object. Ignored.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *
@@ -414,7 +414,7 @@ class ParserPowerSimple {
 	/**
 	 * This function performs the test for the ueswitch function.
 	 *
-	 * @param Parser  $parser The parser object.
+	 * @param Parser  $parser The parser object. Ignored.
 	 * @param PPFrame $frame  The parser frame object.
 	 * @param array   $params The parameters and values together, not yet expanded or trimmed.
 	 *

--- a/includes/ParserPowerSortKeyValueComparer.php
+++ b/includes/ParserPowerSortKeyValueComparer.php
@@ -52,7 +52,7 @@ class ParserPowerSortKeyValueComparer {
 	public function compare($pair1, $pair2) {
 		$result = call_user_func($this->mSortKeyCompare, $pair1[0], $pair2[0]);
 
-		if ($result == 0) {
+		if ($result === 0) {
 			if ($this->mValueCompare) {
 				return call_user_func($this->mValueCompare, $pair1[1], $pair2[1]);
 			} else {
@@ -66,7 +66,7 @@ class ParserPowerSortKeyValueComparer {
 	/**
 	 * Get Comparer class
 	 *
-	 * @param array $options
+	 * @param int $options
 	 *
 	 * @return void
 	 */

--- a/includes/ParserPowerSortKeyValueComparer.php
+++ b/includes/ParserPowerSortKeyValueComparer.php
@@ -17,7 +17,7 @@ class ParserPowerSortKeyValueComparer {
 	 *
 	 * @var callable
 	 */
-	private $mSortKeyCompare = 'ParserPower\\ParserPowerCompare::numericstrcmp';
+	private $mSortKeyCompare = [ ParserPowerCompare::class, 'numericstrcmp' ];
 
 	/**
 	 * The function to use to compare values, if any.
@@ -73,20 +73,20 @@ class ParserPowerSortKeyValueComparer {
 	private function getComparer($options) {
 		if ($options & ParserPowerLists::SORT_NUMERIC) {
 			if ($options & ParserPowerLists::SORT_DESC) {
-				return 'ParserPower\\ParserPowerCompare::numericrstrcmp';
+				return [ ParserPowerCompare::class, 'numericrstrcmp' ];
 			} else {
-				return 'ParserPower\\ParserPowerCompare::numericstrcmp';
+				return [ ParserPowerCompare::class, 'numericstrcmp' ];
 			}
 		} else {
 			if ($options & ParserPowerLists::SORT_CS) {
 				if ($options & ParserPowerLists::SORT_DESC) {
-					return 'ParserPower\\ParserPowerCompare::rstrcmp';
+					return [ ParserPowerCompare::class, 'rstrcmp' ];
 				} else {
 					return 'strcmp';
 				}
 			} else {
 				if ($options & ParserPowerLists::SORT_DESC) {
-					return 'ParserPower\\ParserPowerCompare::rstrcasecmp';
+					return [ ParserPowerCompare::class, 'rstrcasecmp' ];
 				} else {
 					return 'strcasecmp';
 				}


### PR DESCRIPTION
Some documentation fixes:
- arguments missing a type,
- inconsistent use of a `Unused` annotation on arguments,
- copy-paste mistakes, mixing up description of tag functions and parser functions.

Some small code changes:
- change imports of the `Title` class (from *MediaWiki*) to use the namespaced name `MediaWiki\Title\Title` (moved in 1.40),
- use object syntax when specifying callbacks,
- replace use of `==` over `===` for some comparisons with constants.

__Additional note:__ The codesniffer config `mediawiki/mediawiki-codesniffer` specified in composer.json does not support PHP 8. Do you use a different one? Otherwise is it still relevant, or should the base *MediaWiki* one be used instead?