### PR TITLE
`#follow`: Keep fragments with redirects

### DIFF
--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -391,6 +391,12 @@ final class SimpleFunctions {
 			return $text;
 		}
 
+		// Replace redirect fragment with the one from the initial text. We need to check whether there is
+		// a # with no fragment after it, since it removes the redirect fragment if there is one.
+		if ( strpos( $text, '#' ) ) {
+			$target->setFragment( '#' . $title->getFragment() );
+		}
+
 		return $target->getFullText();
 	}
 

--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -380,7 +380,6 @@ final class SimpleFunctions {
 	public static function followRender( Parser $parser, PPFrame $frame, array $params ) {
 		$text = trim( ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE ) );
 
-		$output = $text;
 		$title = Title::newFromText( $text );
 		if ( $title === null || $title->getNamespace() === NS_MEDIA || $title->getNamespace() < 0 ) {
 			return $text;
@@ -392,7 +391,7 @@ final class SimpleFunctions {
 			return $text;
 		}
 
-		return $target->getPrefixedText();
+		return $target->getFullText();
 	}
 
 	public static function arraymapRender( $parser, $frame, $args ) {

--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -393,8 +393,8 @@ final class SimpleFunctions {
 
 		// Replace redirect fragment with the one from the initial text. We need to check whether there is
 		// a # with no fragment after it, since it removes the redirect fragment if there is one.
-		if ( strpos( $text, '#' ) ) {
-			$target->setFragment( '#' . $title->getFragment() );
+		if ( strpos( $text, '#' ) !== false ) {
+			$target = $target->createFragmentTarget( $title->getFragment() );
 		}
 
 		return $target->getFullText();

--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -382,15 +382,17 @@ final class SimpleFunctions {
 
 		$output = $text;
 		$title = Title::newFromText( $text );
-		if ( $title !== null && $title->getNamespace() !== NS_MEDIA && $title->getNamespace() > -1 ) {
-			$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
-			$target = $page->getRedirectTarget();
-			if ( $target !== null ) {
-				$output = $target->getPrefixedText();
-			}
+		if ( $title === null || $title->getNamespace() === NS_MEDIA || $title->getNamespace() < 0 ) {
+			return $text;
 		}
 
-		return [ $output, 'noparse' => false ];
+		$page = MediaWikiServices::getInstance()->getWikiPageFactory()->newFromTitle( $title );
+		$target = $page->getRedirectTarget();
+		if ( $target === null ) {
+			return $text;
+		}
+
+		return $target->getPrefixedText();
 	}
 
 	public static function arraymapRender( $parser, $frame, $args ) {

--- a/tests/parser/simpleFunctionsTest.txt
+++ b/tests/parser/simpleFunctionsTest.txt
@@ -14,6 +14,14 @@ Redirect
 !! endarticle
 
 !! article
+Redirect X
+!! text
+#REDIRECT [[Target#X]]
+!! endarticle
+
+
+
+!! article
 Target
 !! text
 1
@@ -220,12 +228,14 @@ Target
 !! test
 {{#follow}}
 !! wikitext
-{{#follow: Unknown }} {{#follow: Unknown#Section }}
-{{#follow: Target }} {{#follow: Target#Section }}
-{{#follow: Redirect }} {{#follow: Redirect#Section }}
+{{#follow: Unknown }} {{#follow: Unknown# }} {{#follow: Unknown#Section }}
+{{#follow: Target }} {{#follow: Target# }} {{#follow: Target#Section }}
+{{#follow: Redirect }} {{#follow: Redirect# }} {{#follow: Redirect#Section }}
+{{#follow: Redirect X }} {{#follow: Redirect X# }} {{#follow: Redirect X#Section }}
 !! html/php
-<p>Unknown Unknown#Section
-Target Target#Section
-Target Target
+<p>Unknown Unknown# Unknown#Section
+Target Target# Target#Section
+Target Target Target#Section
+Target#X Target Target#Section
 </p>
 !! end

--- a/tests/parser/simpleFunctionsTest.txt
+++ b/tests/parser/simpleFunctionsTest.txt
@@ -19,8 +19,6 @@ Redirect X
 #REDIRECT [[Target#X]]
 !! endarticle
 
-
-
 !! article
 Target
 !! text


### PR DESCRIPTION
## Motivation

The `#follow` parser function takes a (page) title as input, and returns the final title after following redirects: If it is a redirect, it returns the title it redirects to, otheriwse if the title isn't a redirect or does not exist, it returns the original title.

For example, let `Target` be an existing title, and `Redirect` a page that redirects to `Target`:
```html
[[Unknown]]  <!-- link goes to Unknown -->
[[Target]]   <!-- link goes to Target  -->
[[Redirect]] <!-- link goes to Target  -->

{{#follow: Unknown  }} <!-- yields Unknown -->
{{#follow: Target   }} <!-- yields Target  -->
{{#follow: Redirect }} <!-- yields Target  -->
```

As presented in the original documentation, this may be used to help storing and managing links in Cargo tables. However, the `#follow` function does not manage fragments (and its documentation does not mention fragments), so `Redirect#section` is replaced by `Target`. This is a limitation that makes this function less useful, particularly when a page may contain multiple sections, and we really want to keep the section information (e.g. a personal use case on [the BoI:R wiki](https://bindingofisaacrebirth.wiki.gg/wiki/Gaper), where an enemy has multiple variants and each variant redirection page, redirects to its associated section).

For example, let `Redirect X` be a page that redirects to `Target#X`:
```html
[[Redirect]]     <!-- link goes to Target   -->
[[Redirect#]]    <!-- link goes to Target   -->
[[Redirect#Y]]   <!-- link goes to Target#Y -->

[[Redirect X]]   <!-- link goes to Target#X -->
[[Redirect X#]]  <!-- link goes to Target   -->
[[Redirect X#Y]] <!-- link goes to Target#Y -->

{{#follow: Redirect     }} <!-- yields Target -->
{{#follow: Redirect#    }} <!-- yields Target -->
{{#follow: Redirect#Y   }} <!-- yields Target -->

{{#follow: Redirect X   }} <!-- yields Target -->
{{#follow: Redirect X#  }} <!-- yields Target -->
{{#follow: Redirect X#Y }} <!-- yields Target -->
```

## Proposed changes

Make the `#follow` function return a title (optionally with fragment) that would link to the exact same page and section that would be linked to, using the original title text.

The title without the section name, could then be obtained with `{{#titleparts: {{#follow: ... }} }}` using ParserFunctions, or `{{#lstind: 0 | {{#follow: ... }} | # }}` with ParserPower only.

Some templates may rely on the fact that `{{#follow: x }}` would be the same as `x` if it is not a redirect, e.g.
```
{{{1}}} is {{#ifeq: {{#follow: {{{1}}} }} | {{{1}}} | not }} a redirect
```
To keep this behavior, this PR does not change what is returned when the given title is not a redirect.

Below is a list of what is currently returned by the `#follow` function, and what it would return with this proposal:

| `x`            | Current `{{#follow: x }}` | Proposed `{{#follow: x }}` |
|----------------|---------------------------|----------------------------|
| `Unknown`      | `Unknown`                 | `Unknown`                  |
| `Unknown#`     | `Unknown#`                | `Unknown#`                 |
| `Unknown#Y`    | `Unknown#Y`               | `Unknown#Y`                |
| `Target`       | `Target`                  | `Target`                   |
| `Target#`      | `Target#`                 | `Target#`                  |
| `Target#Y`     | `Target#Y`                | `Target#Y`                 |
| `Redirect`     | `Target`                  | `Target`                   |
| `Redirect#`    | `Target`                  | `Target`                   |
| `Redirect#Y`   | `Target`                  | `Target#Y`                 |
| `Redirect X`   | `Target`                  | `Target#X`                 |
| `Redirect X#`  | `Target`                  | `Target`                   |
| `Redirect X#Y` | `Target`                  | `Target#Y`                 |
