### PR TITLE
`#listmerge`: Remove `0 count` suffix on empty output

### DIFF
--- a/includes/ListFunctions.php
+++ b/includes/ListFunctions.php
@@ -2240,7 +2240,7 @@ final class ListFunctions {
 		$default
 	) {
 		if ( $inList === '' ) {
-			return [ $default . 'no input', 'noparse' => false ];
+			return [ $default, 'noparse' => false ];
 		}
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
@@ -2277,7 +2277,7 @@ final class ListFunctions {
 		}
 
 		if ( count( $outValues ) === 0 ) {
-			return [ $default . '0 count', 'noparse' => false ];
+			return [ $default, 'noparse' => false ];
 		}
 
 		$outList = implode( $outSep, $outValues );


### PR DESCRIPTION
## Context

The `#listmerge` parser function adds a `0 count` suffix to the returned default value, if the list is empty after all list operations. For example;

```html
"{{#listmerge: | list =     | matchpattern = no | default =   }}" <!-- yields "" -->
"{{#listmerge: | list = ,,, | matchpattern = no | default =   }}" <!-- yields "0 count" -->
"{{#listmerge: | list = ,,, | matchpattern = no | default = X }}" <!-- yields "X0 count" -->
```

I assume these are debug strings, left in the code a few years ago.

## Proposed changes

Remove these suffixes.