### PR TITLE
`#lstfltr`/`#lstrm`: Parse parameters as indexed instead of named

### DIFF
--- a/includes/ListFunctions.php
+++ b/includes/ListFunctions.php
@@ -1108,8 +1108,6 @@ final class ListFunctions {
 	 * @return array The function output along with relevant parser options.
 	 */
 	public static function lstfltrRender( Parser $parser, PPFrame $frame, array $params ) {
-		$params = ParserPower::arrangeParams( $frame, $params );
-
 		$inList = ParserPower::expand( $frame, $params[2] ?? '' );
 
 		if ( $inList === '' ) {
@@ -1145,8 +1143,6 @@ final class ListFunctions {
 	 * @return array The function output along with relevant parser options.
 	 */
 	public static function lstrmRender( Parser $parser, PPFrame $frame, array $params ) {
-		$params = ParserPower::arrangeParams( $frame, $params );
-
 		$inList = ParserPower::expand( $frame, $params[1] ?? '' );
 
 		if ( $inList === '' ) {


### PR DESCRIPTION
## Context

ParserPower provides various list functions that apply a template/pattern to each value or pair of values. Since they accept a lot of parameters, the parameters are named, and keys/values are split at the start using an `arrangeParams` function.

Some of these functions provide smaller alternatives, when most of these parameters are unused:
- `#listunique` has `#lstuniq`,
- `#listfilter` has `#lstfltr` and `#lstrm`,
- `#listsort` has `#lstsrt`,
- `#listmap` has `#lstmap` and `#lstmaptemp`.

These smaller functions accept unnamed parameters, so they do not call `arrangeParams`, and use array indices to find specific parameters.

However, the `#lstfltr` and `#lstrm` parser functions, while accepting unnamed parameters, call the `arrangeParams` function. This means:
- if the value contains an `=`, the parameter is no longer recognized,
- values are evaluated twice,
- parameters are always evaluated, while other functions with unnamed parameters are mostly lazy when the processed list is empty.

I assume this is a copy paste error from when these functions were originally introduced.

## Proposed changes

Remove the `arrangeParams` call from the `#lstfltr` and `#lstrm` function handlers.