### PR TITLE
`#ueswitch`: Evaluate arguments more lazily

### DIFF
--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -369,11 +369,11 @@ final class SimpleFunctions {
 			}
 		}
 
-		$lastBits = $params[count( $params ) - 1]->splitArg();
-		if ( $lastBits['index'] !== '' ) {
-			$default = $lastBits['value'];
+		if ( $value === null ) {
+			return [ is_string( $key ) ? $key : ParserPower::expand( $frame, $key, ParserPower::UNESCAPE ), 'noparse' => false ];
+		} else {
+			return [ ParserPower::expand( $frame, $default, ParserPower::UNESCAPE ), 'noparse' => false ];
 		}
-		return [ ParserPower::expand( $frame, $default, ParserPower::UNESCAPE ), 'noparse' => false ];
 	}
 
 	/**

--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -344,7 +344,7 @@ final class SimpleFunctions {
 			$bits = $param->splitArg();
 			if ( $bits['index'] === '' ) {
 				$key = ParserPower::expand( $frame, $bits['name'] );
-				$value = ParserPower::expand( $frame, $bits['value'] );
+				$value = $bits['value'];
 			} else {
 				$key = ParserPower::expand( $frame, $bits['value'] );
 				$value = null;
@@ -361,7 +361,7 @@ final class SimpleFunctions {
 
 			if ( $value !== null ) {
 				if ( $keyFound ) {
-					return [ ParserPower::unescape( $value ), 'noparse' => false ];
+					return [ ParserPower::expand( $frame, $value, ParserPower::UNESCAPE ), 'noparse' => false ];
 				} elseif ( $mwDefaultFound ) {
 					$default = $value;
 					$mwDefaultFound = false;

--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -343,15 +343,15 @@ final class SimpleFunctions {
 		foreach ( $params as $param ) {
 			$bits = $param->splitArg();
 			if ( $bits['index'] === '' ) {
-				$key = ParserPower::expand( $frame, $bits['name'] );
+				$key = $bits['name'];
 				$value = $bits['value'];
 			} else {
-				$key = ParserPower::expand( $frame, $bits['value'] );
+				$key = $bits['value'];
 				$value = null;
 			}
 
 			if ( !$keyFound ) {
-				$key = ParserPower::unescape( $key );
+				$key = ParserPower::expand( $frame, $key, ParserPower::UNESCAPE );
 				if ( $key === $switchKey ) {
 					$keyFound = true;
 				} elseif ( $mwDefault->matchStartToEnd( $key ) ) {

--- a/includes/SimpleFunctions.php
+++ b/includes/SimpleFunctions.php
@@ -335,10 +335,6 @@ final class SimpleFunctions {
 			return [ '', 'noparse' => false ];
 		}
 
-		$lastBits = $params[count( $params ) - 1]->splitArg();
-		$frame->expand( $lastBits['name'] );
-		$lastValue = $frame->expand( $lastBits['value'] );
-
 		$default = '';
 		$mwDefaultFound = false;
 		$mwDefault = $parser->getMagicWordFactory()->get( 'default' );
@@ -373,8 +369,9 @@ final class SimpleFunctions {
 			}
 		}
 
+		$lastBits = $params[count( $params ) - 1]->splitArg();
 		if ( $lastBits['index'] !== '' ) {
-			$default = $lastValue;
+			$default = $lastBits['value'];
 		}
 		return [ ParserPower::expand( $frame, $default, ParserPower::UNESCAPE ), 'noparse' => false ];
 	}


### PR DESCRIPTION
This PR is about making the `#ueswitch` parser function lazier, the same way as the the `#switch` function. This includes the differences presented in #3, and a few others.

## Context

The `#switch` function from ParserFunctions (PF) is lazy when evaluating its parameters (apart from a few edge cases) and evaluate each of its parameters at most once. ParserPower (PP) provides the `#ueswitch` function, which is also lazy, but not as much as PF, and may evaluate the default values twice.

Both parameter evaluation strategies are rewritten below, only including relevant code, using a similar convention, and omitting some quirks.

### ParserFunctions (PF)

`{{#switch: value | k1 = v1 | k2 | k3 = v3 | ... | kn }}`
1. __Evaluate `value`__.
2. For each increasing `i`:
   1. If `vi` exists:
      1. If any previous `kj` matched:
         1. __Evaluate `vi`__ and return it.
      2. __Evaluate `ki`__.
      3. If `ki` matches:
         1. __Evaluate `vi`__ and return it.
      4. If `ki` or any previous `kj` is `#default`:
         1. Set `vi` as the default value.
   2. Else:
      1. __Evaluate `ki`__.
      2. If `ki` matches, remember it.
      3. Else if `ki` is `#default`, remember it.
3. If `vn` exists:
   1. __Evaluate the default value__ and return it.
4. Return `kn`.

### ParserPower (PP)

`{{#ueswitch: value | k1 = v1 | k2 | k3 = v3 | ... | kn }}`
1. __Evaluate `value`__.
2. __Evaluate `kn` and `vn`__ (if it exists).
3. For each increasing `i`:
   1. __Evaluate `ki`__.
   2. If `vi` exists:
      1. __Evaluate `vi`__.
      2. If any previous `kj` matched:
         1. Return `vi`.
      3. If `ki` matches:
         1. Return `vi`.
      4. If `ki` or any previous `kj` is `#default`:
         1. Set `vi` as the default value.
   3. Else:
      1. If `ki` matches, remember it.
      2. Else if `ki` is `#default`, remember it.
4. If `vn` exists:
   1. __Evaluate the default value__ and return it.
5. __Evaluate `kn`__ and return it.

### Issues with the ParserPower approach

An example of the laziness issues are in the description of #3.

As introduced above, the PP function does not any parameter will be evaluated at most once. In practice, it will evaluate and unescape the default value twice (steps PP 3.i and PP 4.i), and one additional time if the default value is specified as the last parameter without an `=` (steps PP 2, PP 3.i, and PP 5).

The ParserPower function also evaluates the last parameter at the start (step PP 2), which can produce unintuitive behaviors, as variables set in this field will be evaluated before other case keys and values.

## Proposed changes

Make `#ueswitch` evaluate its arguments the same way and in the same order as `#switch`.

More precisely, mapping directly to the commits of this PR:

1. Do not evaluate the last parameter at the start, only last if no keys matched.
   - (remove PP 2)
3. Do not evaluate case values if the key(s) did not match or is a `#default` magic word.
   - (replace PP 3.ii.a / 3.ii.b.a / 3.ii.c.a with PF 2.i.a.a / 2.i.c.a)
4. Do not evaluate case keys if one already matched.
   - (replace PP 3.i with PF 2.i.b / 2.ii.a)
5. Do not evaluate the last parameter at the end if it has been evaluated in the main loop.
   - (replace PP 5 with PF 4)