### PR TITLE
Add scalar types

### DIFF
--- a/src/ComparisonUtils.php
+++ b/src/ComparisonUtils.php
@@ -13,7 +13,7 @@ final class ComparisonUtils {
 	 * @param string $string2 A string to compare to $string1.
 	 * @return int Number > 0 if str1 is less than str2; Number < 0 if str1 is greater than str2; 0 if they are equal.
 	 */
-	public static function numericstrcmp( $string1, $string2 ) {
+	public static function numericstrcmp( string $string1, string $string2 ): int {
 		return ( is_numeric( $string1 ) ? $string1 : 0 ) - ( is_numeric( $string2 ) ? $string2 : 0 );
 	}
 
@@ -25,7 +25,7 @@ final class ComparisonUtils {
 	 * @param string $string2 A string to compare to $string1.
 	 * @return int Number > 0 if str1 is less than str2; Number < 0 if str1 is greater than str2; 0 if they are equal.
 	 */
-	public static function numericrstrcmp( $string1, $string2 ) {
+	public static function numericrstrcmp( string $string1, string $string2 ): int {
 		return ( is_numeric( $string2 ) ? $string2 : 0 ) - ( is_numeric( $string1 ) ? $string1 : 0 );
 	}
 
@@ -36,7 +36,7 @@ final class ComparisonUtils {
 	 * @param string $string2 A string to compare to $string1.
 	 * @return int Number > 0 if str1 is less than str2; Number < 0 if str1 is greater than str2; 0 if they are equal.
 	 */
-	public static function rstrcmp( $string1, $string2 ) {
+	public static function rstrcmp( string $string1, string $string2 ): int {
 		return strcmp( $string2, $string1 );
 	}
 
@@ -47,7 +47,7 @@ final class ComparisonUtils {
 	 * @param string $string2 A string to compare to $string1.
 	 * @return int Number > 0 if str1 is less than str2; Number < 0 if str1 is greater than str2; 0 if they are equal.
 	 */
-	public static function rstrcasecmp( $string1, $string2 ) {
+	public static function rstrcasecmp( string $string1, string $string2 ): int {
 		return strcasecmp( $string2, $string1 );
 	}
 }

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -227,7 +227,11 @@ final class ListFunctions {
 			$values = explode( $sep, $list );
 		}
 
-		return $values;
+		if ( $values === false ) {
+			return [];
+		} else {
+			return $values;
+		}
 	}
 
 	/**
@@ -235,13 +239,13 @@ final class ListFunctions {
 	 * the empty values are skipped in index counting. The returned element is unescaped.
 	 *
 	 * @param int $inIndex The 1-based index of the array element to get, or a negative value to start from the end.
-	 * @param ?array $inValues The array to get the element from.
+	 * @param array $inValues The array to get the element from.
 	 * @return string The array element, trimmed and with character escapes replaced, or empty string if not found.
 	 */
-	private static function arrayElementTrimUnescape( int $inIndex, ?array $inValues ): string {
+	private static function arrayElementTrimUnescape( int $inIndex, array $inValues ): string {
 		if ( $inIndex > 0 ) {
 			$curOutIndex = 1;
-			$count = ( is_array( $inValues ) || $inValues instanceof Countable ) ? count( $inValues ) : 0;
+			$count = count( $inValues );
 			for ( $curInIndex = 0; $curInIndex < $count; ++$curInIndex ) {
 				$trimmedValue = trim( $inValues[$curInIndex] );
 				if ( !ParserPower::isEmpty( $trimmedValue ) ) {

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -235,7 +235,7 @@ final class ListFunctions {
 	 * the empty values are skipped in index counting. The returned element is unescaped.
 	 *
 	 * @param int $inIndex The 1-based index of the array element to get, or a negative value to start from the end.
-	 * @param array|null $inValues The array to get the element from.
+	 * @param ?array $inValues The array to get the element from.
 	 * @return string The array element, trimmed and with character escapes replaced, or empty string if not found.
 	 */
 	private static function arrayElementTrimUnescape( $inIndex, $inValues ) {
@@ -992,7 +992,7 @@ final class ListFunctions {
 	 * @param string $fieldSep Separator between fields, if any.
 	 * @param string $indexToken Replace the current 1-based index of the element. Null/empty to skip.
 	 * @param string $token The token in the pattern that represents where the list value should go.
-	 * @param array|null $tokens Or if there are mulitple fields, the tokens representing where they go.
+	 * @param ?array $tokens Or if there are mulitple fields, the tokens representing where they go.
 	 * @param string $pattern The pattern of text containing token that list values are inserted into at that token.
 	 * @return array An array with only values that generated unique keys via the given pattern.
 	 */
@@ -1178,7 +1178,7 @@ final class ListFunctions {
 	 * @param string $fieldSep Separator between fields, if any.
 	 * @param int $indexToken
 	 * @param string $token The token in the pattern that represents where the list value should go.
-	 * @param array|null $tokens Or if there are mulitple fields, the tokens representing where they go.
+	 * @param ?array $tokens Or if there are mulitple fields, the tokens representing where they go.
 	 * @param string $pattern The pattern of text containing token that list values are inserted into at that token.
 	 * @return array An array where each value has been paired with a sort key in a two-element array.
 	 */
@@ -1289,7 +1289,7 @@ final class ListFunctions {
 	 * @param string $fieldSep The delimiter separating values in the input list.
 	 * @param string $indexToken Replace the current 1-based index of the element. Null/empty to skip.
 	 * @param string $token The token in the pattern that represents where the list value should go.
-	 * @param array|null $tokens Or if there are mulitple fields, the tokens representing where they go.
+	 * @param ?array $tokens Or if there are mulitple fields, the tokens representing where they go.
 	 * @param string $pattern The pattern containing token that list values are inserted into at that token.
 	 * @return array An array where each value has been paired with a sort key in a two-element array.
 	 */
@@ -1823,7 +1823,7 @@ final class ListFunctions {
 	 * @param array $tokens1 The list of tokens to replace when performing the replacement for $inValue1.
 	 * @param array $tokens2 The list of tokens to replace when performing the replacement for $inValue2.
 	 * @param string $pattern Pattern containing tokens to be replaced by field (or unsplit) values.
-	 * @return string The result of the token replacement within the pattern.
+	 * @return string|void The result of the token replacement within the pattern.
 	 */
 	private static function applyTwoSetFieldPattern(
 		Parser $parser,
@@ -1894,7 +1894,7 @@ final class ListFunctions {
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.
 	 * @param array $values The input values, should be already exploded and fully preprocessed.
-	 * @param string $applyFunction Valid name of the function to call for both match and merge processes.
+	 * @param callable $applyFunction Valid name of the function to call for both match and merge processes.
 	 * @param array $matchParams Parameter values for the matching process, with open spots for the values.
 	 * @param array $mergeParams Parameter values for the merging process, with open spots for the values.
 	 * @param int $valueIndex1 The index in $matchParams and $mergeParams where the first value is to go.

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -60,7 +60,7 @@ final class ListFunctions {
 	 * @param bool $default Value that should be used by default.
 	 * @return bool
 	 */
-	public static function decodeBool( $text, $default = false ) {
+	public static function decodeBool( string $text, bool $default = false ): bool {
 		$text = strtolower( $text );
 		switch ( $text ) {
 			case 'yes':
@@ -79,7 +79,7 @@ final class ListFunctions {
 	 * @param int $default Any flags that should be set by default.
 	 * @return int The flags representing the requested mode.
 	 */
-	public static function decodeDuplicates( $text, $default = 0 ) {
+	public static function decodeDuplicates( string $text, int $default = 0 ): int {
 		$text = strtolower( $text );
 		switch ( $text ) {
 			case 'keep':
@@ -104,7 +104,7 @@ final class ListFunctions {
 	 * @param bool $default Value that should be used by default.
 	 * @return bool True if case sentitive, false otherwise.
 	 */
-	public static function decodeCSOption( $text, $default = false ) {
+	public static function decodeCSOption( string $text, bool $default = false ): bool {
 		$text = strtolower( $text );
 		switch ( $text ) {
 			case 'cs':
@@ -123,7 +123,7 @@ final class ListFunctions {
 	 * @param int $default Any flags that should be set by default.
 	 * @return int The flags representing the requested mode.
 	 */
-	public static function decodeSortMode( $text, $default = 0 ) {
+	public static function decodeSortMode( string $text, int $default = 0 ): int {
 		$text = strtolower( $text );
 		switch ( $text ) {
 			case 'nosort':
@@ -148,7 +148,7 @@ final class ListFunctions {
 	 * @param int $default Any flags that should be set by default.
 	 * @return int The flags representing the requested options.
 	 */
-	private static function decodeSortOptions( $text, $default = 0 ) {
+	private static function decodeSortOptions( string $text, int $default = 0 ): int {
 		$optionKeywords = explode( ' ', $text );
 		$options = $default;
 		foreach ( $optionKeywords as $optionKeyword ) {
@@ -184,7 +184,7 @@ final class ListFunctions {
 	 * @param int $default Any flags that should be set by default.
 	 * @return int The flags representing the requested options.
 	 */
-	private static function decodeIndexOptions( $text, $default = 0 ) {
+	private static function decodeIndexOptions( string $text, int $default = 0 ): int {
 		$optionKeywords = explode( ' ', $text );
 		$options = $default;
 		foreach ( $optionKeywords as $optionKeyword ) {
@@ -220,7 +220,7 @@ final class ListFunctions {
 	 * @param string $list The list in string format with values separated by the given or default delimiters.
 	 * @return array The values in an array of strings.
 	 */
-	private static function explodeList( $sep, $list ) {
+	private static function explodeList( string $sep, string $list ): array {
 		if ( $sep === '' ) {
 			$values = preg_split( '/(.)/u', $list, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
 		} else {
@@ -238,7 +238,7 @@ final class ListFunctions {
 	 * @param ?array $inValues The array to get the element from.
 	 * @return string The array element, trimmed and with character escapes replaced, or empty string if not found.
 	 */
-	private static function arrayElementTrimUnescape( $inIndex, $inValues ) {
+	private static function arrayElementTrimUnescape( int $inIndex, ?array $inValues ): string {
 		if ( $inIndex > 0 ) {
 			$curOutIndex = 1;
 			$count = ( is_array( $inValues ) || $inValues instanceof Countable ) ? count( $inValues ) : 0;
@@ -275,11 +275,11 @@ final class ListFunctions {
 	 * that are only empty after the unescape are preserved.
 	 *
 	 * @param int $inOffset
-	 * @param int $inLength
+	 * @param ?int $inLength
 	 * @param array $inValues The array to trim, remove empty values from, slice, and unescape.
 	 * @return array A new array with trimmed values, character escapes replaced, and empty values pre unescape removed.
 	 */
-	private static function arrayTrimSliceUnescape( $inOffset, $inLength, array $inValues ) {
+	private static function arrayTrimSliceUnescape( int $inOffset, ?int $inLength, array $inValues ): array {
 		$midValues = [];
 		$outValues = [];
 
@@ -320,7 +320,7 @@ final class ListFunctions {
 	 * @param array $inValues The array to trim, unescape, and remove empty values from.
 	 * @return array A new array with trimmed values, character escapes replaced, and empty values preunescape removed.
 	 */
-	private static function arrayTrimUnescape( array $inValues ) {
+	private static function arrayTrimUnescape( array $inValues ): array {
 		$outValues = [];
 
 		foreach ( $inValues as $inValue ) {
@@ -341,7 +341,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstcntRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstcntRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$list = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $list === '' ) {
@@ -363,7 +363,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstsepRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstsepRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -387,7 +387,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output along with relevant parser options.
 	 */
-	public function lstelemRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstelemRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -417,7 +417,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstsubRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstsubRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -458,7 +458,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstfndRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstfndRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$list = ParserPower::expand( $frame, $params[1] ?? '' );
 
 		if ( $list === '' ) {
@@ -497,7 +497,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstindRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstindRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$list = ParserPower::expand( $frame, $params[1] ?? '' );
 
 		if ( $list === '' ) {
@@ -553,7 +553,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstappRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstappRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$list = ParserPower::expand( $frame, $params[0] ?? '' );
 		$value = ParserPower::expand( $frame, $params[2] ?? '', ParserPower::UNESCAPE );
 
@@ -580,7 +580,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstprepRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstprepRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$value = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
 		$list = ParserPower::expand( $frame, $params[2] ?? '' );
 
@@ -607,7 +607,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstjoinRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstjoinRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList1 = ParserPower::expand( $frame, $params[0] ?? '' );
 		$inList2 = ParserPower::expand( $frame, $params[2] ?? '' );
 
@@ -648,7 +648,7 @@ final class ListFunctions {
 	 * @param int $count The count to replace the token with.
 	 * @return string The content wrapped by the intro and outro.
 	 */
-	private static function applyIntroAndOutro( $intro, $content, $outro, $countToken, $count ) {
+	private static function applyIntroAndOutro( string $intro, string $content, string $outro, string $countToken, int $count ): string {
 		if ( $countToken !== null && $countToken !== '' ) {
 			$intro = str_replace( $countToken, (string)$count, $intro );
 			$outro = str_replace( $countToken, (string)$count, $outro );
@@ -665,7 +665,7 @@ final class ListFunctions {
 	 * @param bool $valueCS true to match in a case-sensitive manner, false to match in a case-insensitive manner
 	 * @return array The array stripped of any values with non-unique keys.
 	 */
-	private static function filterListByInclusion( array $inValues, $values, $valueSep, $valueCS ) {
+	private static function filterListByInclusion( array $inValues, string $values, string $valueSep, bool $valueCS ): array {
 		if ( $valueSep !== '' ) {
 			$includeValues = self::arrayTrimUnescape( self::explodeList( $valueSep, $values ) );
 		} else {
@@ -694,7 +694,7 @@ final class ListFunctions {
 	 * @param bool $valueCS true to match in a case-sensitive manner, false to match in a case-insensitive manner
 	 * @return array The array stripped of any values with non-unique keys.
 	 */
-	private static function filterListByExclusion( array $inValues, $values, $valueSep, $valueCS ) {
+	private static function filterListByExclusion( array $inValues, string $values, string $valueSep, bool $valueCS ): array {
 		if ( $valueSep !== '' ) {
 			$excludeValues = self::arrayTrimUnescape( self::explodeList( $valueSep, $values ) );
 		} else {
@@ -731,12 +731,12 @@ final class ListFunctions {
 		Parser $parser,
 		PPFrame $frame,
 		array $inValues,
-		$fieldSep,
-		$indexToken,
-		$token,
-		$tokenSep,
-		$pattern
-	) {
+		string $fieldSep,
+		string $indexToken,
+		string $token,
+		string $tokenSep,
+		string $pattern
+	): array {
 		$outValues = [];
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
 			$tokens = array_map( 'trim', explode( $tokenSep, $token ) );
@@ -775,7 +775,13 @@ final class ListFunctions {
 	 * @param string $fieldSep Separator between fields, if any.
 	 * @return array The array stripped of any values with non-unique keys.
 	 */
-	private static function filterFromListByTemplate( Parser $parser, PPFrame $frame, array $inValues, $template, $fieldSep ) {
+	private static function filterFromListByTemplate(
+		Parser $parser,
+		PPFrame $frame,
+		array $inValues,
+		string $template,
+		string $fieldSep
+	): array {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		$outValues = [];
@@ -807,7 +813,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function listfilterRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function listfilterRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$params = ParserPower::arrangeParams( $frame, $params );
 
 		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
@@ -880,7 +886,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstfltrRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstfltrRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[2] ?? '' );
 
 		if ( $inList === '' ) {
@@ -915,7 +921,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstrmRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstrmRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[1] ?? '' );
 
 		if ( $inList === '' ) {
@@ -946,9 +952,9 @@ final class ListFunctions {
 	 *
 	 * @param array $values The array of values to reduce to unique values.
 	 * @param bool $valueCS true to determine uniqueness case-sensitively, false to determine it case-insensitively
-	 * @return string The function output.
+	 * @return array The function output.
 	 */
-	private static function reduceToUniqueValues( array $values, $valueCS ) {
+	private static function reduceToUniqueValues( array $values, bool $valueCS ): array {
 		if ( $valueCS ) {
 			return array_unique( $values );
 		} else {
@@ -964,7 +970,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstcntuniqRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstcntuniqRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -1000,12 +1006,12 @@ final class ListFunctions {
 		Parser $parser,
 		PPFrame $frame,
 		array $inValues,
-		$fieldSep,
-		$indexToken,
-		$token,
-		$tokens,
-		$pattern
-	) {
+		string $fieldSep,
+		string $indexToken,
+		string $token,
+		?array $tokens,
+		string $pattern
+	): array {
 		$previousKeys = [];
 		$outValues = [];
 		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
@@ -1052,9 +1058,9 @@ final class ListFunctions {
 		Parser $parser,
 		PPFrame $frame,
 		array $inValues,
-		$template,
-		$fieldSep
-	) {
+		string $template,
+		string $fieldSep
+	): array {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		$previousKeys = [];
@@ -1089,7 +1095,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function listuniqueRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function listuniqueRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$params = ParserPower::arrangeParams( $frame, $params );
 
 		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
@@ -1149,7 +1155,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstuniqRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstuniqRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -1176,7 +1182,7 @@ final class ListFunctions {
 	 * @param PPFrame $frame The parser frame object.
 	 * @param array $values The input list.
 	 * @param string $fieldSep Separator between fields, if any.
-	 * @param int $indexToken
+	 * @param string $indexToken
 	 * @param string $token The token in the pattern that represents where the list value should go.
 	 * @param ?array $tokens Or if there are mulitple fields, the tokens representing where they go.
 	 * @param string $pattern The pattern of text containing token that list values are inserted into at that token.
@@ -1186,12 +1192,12 @@ final class ListFunctions {
 		Parser $parser,
 		PPFrame $frame,
 		array $values,
-		$fieldSep,
-		$indexToken,
-		$token,
-		$tokens,
-		$pattern
-	) {
+		string $fieldSep,
+		string $indexToken,
+		string $token,
+		?array $tokens,
+		string $pattern
+	): array {
 		$pairedValues = [];
 		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
 			$tokenCount = count( $tokens );
@@ -1227,7 +1233,13 @@ final class ListFunctions {
 	 * @param string $fieldSep Separator between fields, if any.
 	 * @return array An array where each value has been paired with a sort key in a two-element array.
 	 */
-	private static function generateSortKeysByTemplate( Parser $parser, PPFrame $frame, array $values, $template, $fieldSep ) {
+	private static function generateSortKeysByTemplate(
+		Parser $parser,
+		PPFrame $frame,
+		array $values,
+		string $template,
+		string $fieldSep
+	): array {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		$pairedValues = [];
@@ -1251,7 +1263,7 @@ final class ListFunctions {
 	 * @param array $pairedValues An array with values paired with sort keys.
 	 * @return array An array with just the values.
 	 */
-	private static function discardSortKeys( array $pairedValues ) {
+	private static function discardSortKeys( array $pairedValues ): array {
 		$values = [];
 
 		foreach ( $pairedValues as $pairedValue ) {
@@ -1268,7 +1280,7 @@ final class ListFunctions {
 	 * @param array $pairedValues An array with values paired with sort keys.
 	 * @return array An array with just the sort keys wrapped in <nowiki>..
 	 */
-	private static function discardValues( array $pairedValues ) {
+	private static function discardValues( array $pairedValues ): array {
 		$values = [];
 
 		foreach ( $pairedValues as $pairedValue ) {
@@ -1298,13 +1310,13 @@ final class ListFunctions {
 		PPFrame $frame,
 		ListSorter $sorter,
 		array $values,
-		$template,
-		$fieldSep,
-		$indexToken,
-		$token,
-		$tokens,
-		$pattern
-	) {
+		string $template,
+		string $fieldSep,
+		string $indexToken,
+		string $token,
+		?array $tokens,
+		string $pattern
+	): array {
 		if ( $template !== '' ) {
 			$pairedValues = self::generateSortKeysByTemplate( $parser, $frame, $values, $template, $fieldSep );
 		} else {
@@ -1333,7 +1345,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function listsortRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function listsortRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$params = ParserPower::arrangeParams( $frame, $params );
 
 		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
@@ -1417,7 +1429,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstsrtRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstsrtRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -1462,22 +1474,22 @@ final class ListFunctions {
 	private static function applyPatternToList(
 		Parser $parser,
 		PPFrame $frame,
-		$inList,
-		$inSep,
-		$fieldSep,
-		$indexToken,
-		$token,
-		$tokenSep,
-		$pattern,
-		$outSep,
-		$sortMode,
-		$sortOptions,
-		$duplicates,
-		$countToken,
-		$intro,
-		$outro,
-		$default
-	) {
+		string $inList,
+		string $inSep,
+		string $fieldSep,
+		string $indexToken,
+		string $token,
+		string $tokenSep,
+		string $pattern,
+		string $outSep,
+		int $sortMode,
+		int $sortOptions,
+		int $duplicates,
+		string $countToken,
+		string $intro,
+		string $outro,
+		string $default
+	): string {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
@@ -1562,19 +1574,19 @@ final class ListFunctions {
 	private static function applyTemplateToList(
 		Parser $parser,
 		PPFrame $frame,
-		$inList,
-		$template,
-		$inSep,
-		$fieldSep,
-		$outSep,
-		$sortMode,
-		$sortOptions,
-		$duplicates,
-		$countToken,
-		$intro,
-		$outro,
-		$default
-	) {
+		string $inList,
+		string $template,
+		string $inSep,
+		string $fieldSep,
+		string $outSep,
+		int $sortMode,
+		int $sortOptions,
+		int $duplicates,
+		string $countToken,
+		string $intro,
+		string $outro,
+		string $default
+	): string {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
@@ -1631,7 +1643,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function listmapRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function listmapRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$params = ParserPower::arrangeParams( $frame, $params );
 
 		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
@@ -1708,7 +1720,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstmapRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstmapRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -1754,7 +1766,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function lstmaptempRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function lstmaptempRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inList === '' ) {
@@ -1828,12 +1840,12 @@ final class ListFunctions {
 	private static function applyTwoSetFieldPattern(
 		Parser $parser,
 		PPFrame $frame,
-		$inValue1,
-		$inValue2,
-		$fieldSep,
+		string $inValue1,
+		string $inValue2,
+		string $fieldSep,
 		array $tokens1,
 		array $tokens2,
-		$pattern
+		string $pattern
 	) {
 		$tokenCount1 = count( $tokens1 );
 		$tokenCount2 = count( $tokens2 );
@@ -1870,11 +1882,11 @@ final class ListFunctions {
 	private static function applyTemplateToTwoValues(
 		Parser $parser,
 		PPFrame $frame,
-		$inValue1,
-		$inValue2,
-		$template,
-		$fieldSep
-	) {
+		string $inValue1,
+		string $inValue2,
+		string $template,
+		string $fieldSep
+	): string {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		if ( $fieldSep === '' ) {
@@ -1905,12 +1917,12 @@ final class ListFunctions {
 		Parser $parser,
 		PPFrame $frame,
 		array $values,
-		$applyFunction,
+		callable $applyFunction,
 		array $matchParams,
 		array $mergeParams,
-		$valueIndex1,
-		$valueIndex2
-	) {
+		int $valueIndex1,
+		int $valueIndex2
+	): array {
 		$checkedPairs = [];
 
 		do {
@@ -1974,22 +1986,22 @@ final class ListFunctions {
 	private static function mergeListByPattern(
 		Parser $parser,
 		PPFrame $frame,
-		$inList,
-		$inSep,
-		$fieldSep,
-		$token1,
-		$token2,
-		$tokenSep,
-		$matchPattern,
-		$mergePattern,
-		$outSep,
-		$sortMode,
-		$sortOptions,
-		$countToken,
-		$intro,
-		$outro,
-		$default
-	) {
+		string $inList,
+		string $inSep,
+		string $fieldSep,
+		string $token1,
+		string $token2,
+		string $tokenSep,
+		string $matchPattern,
+		string $mergePattern,
+		string $outSep,
+		int $sortMode,
+		int $sortOptions,
+		string $countToken,
+		string $intro,
+		string $outro,
+		string $default
+	): string {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
@@ -2060,19 +2072,19 @@ final class ListFunctions {
 	private static function mergeListByTemplate(
 		Parser $parser,
 		PPFrame $frame,
-		$inList,
-		$matchTemplate,
-		$mergeTemplate,
-		$inSep,
-		$fieldSep,
-		$outSep,
-		$sortMode,
-		$sortOptions,
-		$countToken,
-		$intro,
-		$outro,
-		$default
-	) {
+		string $inList,
+		string $matchTemplate,
+		string $mergeTemplate,
+		string $inSep,
+		string $fieldSep,
+		string $outSep,
+		int $sortMode,
+		int $sortOptions,
+		string $countToken,
+		string $intro,
+		string $outro,
+		string $default
+	): string {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
@@ -2122,7 +2134,7 @@ final class ListFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function listmergeRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function listmergeRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$params = ParserPower::arrangeParams( $frame, $params );
 
 		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -6,6 +6,7 @@ namespace MediaWiki\Extension\ParserPower;
 
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
+use MediaWiki\Parser\PPNode;
 use MediaWiki\Parser\Preprocessor;
 
 class ParserPower {
@@ -107,7 +108,7 @@ class ParserPower {
 	 * @param int $flags
 	 * @return string
 	 */
-	public static function expand( PPFrame $frame, $input, int $flags = 0 ): string {
+	public static function expand( PPFrame $frame, PPNode|string $input, int $flags = 0 ): string {
 		if ( $flags & self::NO_VARS ) {
 			$expanded = $frame->expand( $input, PPFrame::NO_ARGS | PPFrame::NO_TEMPLATES );
 		} else {

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -65,7 +65,7 @@ class ParserPower {
 	 * @param array $unexpandedParams The parameters and values together, not yet exploded or trimmed.
 	 * @return array The parameter values associated with the appropriate named or numbered keys
 	 */
-	public static function arrangeParams( PPFrame $frame, array $unexpandedParams ) {
+	public static function arrangeParams( PPFrame $frame, array $unexpandedParams ): array {
 		$params = [];
 
 		if ( isset( $unexpandedParams[0] ) && is_string( $unexpandedParams[0] ) ) {
@@ -95,7 +95,7 @@ class ParserPower {
 	 * @param string $value The value to check.
 	 * @return bool true for a value that is not null or an empty string.
 	 */
-	public static function isEmpty( $value ) {
+	public static function isEmpty( string $value ): bool {
 		return $value === null || $value === '';
 	}
 
@@ -107,7 +107,7 @@ class ParserPower {
 	 * @param int $flags
 	 * @return string
 	 */
-	public static function expand( PPFrame $frame, $input, $flags = 0 ) {
+	public static function expand( PPFrame $frame, $input, int $flags = 0 ): string {
 		if ( $flags & self::NO_VARS ) {
 			$expanded = $frame->expand( $input, PPFrame::NO_ARGS | PPFrame::NO_TEMPLATES );
 		} else {
@@ -133,7 +133,7 @@ class ParserPower {
 	 * @param int $flags
 	 * @return string
 	 */
-	public static function evaluateUnescaped( Parser $parser, PPFrame $frame, $text, $flags = 0 ) {
+	public static function evaluateUnescaped( Parser $parser, PPFrame $frame, string $text, int $flags = 0 ): string {
 		if ( $text === '' ) {
 			return '';
 		}
@@ -157,7 +157,7 @@ class ParserPower {
 	 * @param string $input The string to escape.
 	 * @return string The string with all escape sequences replaced.
 	 */
-	public static function unescape( $input ) {
+	public static function unescape( string $input ): string {
 		$output = '';
 		$offset = 0;
 		$length = strlen( $input );
@@ -197,7 +197,7 @@ class ParserPower {
 	 * @param string $input The string to escape.
 	 * @return string The escaped string.
 	 */
-	public static function escape( $input ) {
+	public static function escape( string $input ): string {
 		$output = '';
 		$offset = 0;
 		$length = strlen( $input );
@@ -252,7 +252,7 @@ class ParserPower {
 	 * @param string $pattern Pattern containing token to be replaced with the input value.
 	 * @return string The result of the token replacement within the pattern.
 	 */
-	public static function applyPattern( $value, $token, $pattern ) {
+	public static function applyPattern( string $value, string $token, string $pattern ): string {
 		if ( $pattern === '' ) {
 			return $value;
 		} else {

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -80,7 +80,7 @@ class ParserPower {
 		foreach ( $unexpandedParams as $unexpandedParam ) {
 			$bits = $unexpandedParam->splitArg();
 			if ( $bits['index'] === '' ) {
-				$params[ParserPower::expand( $frame, $bits['name'] )] = $bits['value'];
+				$params[self::expand( $frame, $bits['name'] )] = $bits['value'];
 			} else {
 				$params[] = $bits['value'];
 			}

--- a/src/SimpleFunctions.php
+++ b/src/SimpleFunctions.php
@@ -24,7 +24,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function trimRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function trimRender( Parser $parser, PPFrame $frame, array $params ): string {
 		return ParserPower::expand( $frame, $params[0] ?? '' );
 	}
 
@@ -37,7 +37,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function uescRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function uescRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$text = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $text );
@@ -53,7 +53,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function uescnowikiRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function uescnowikiRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$text = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, '<nowiki>' . $text . '</nowiki>' );
@@ -68,7 +68,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function trimuescRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function trimuescRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$text = trim( ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE ) );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $text );
@@ -78,9 +78,9 @@ final class SimpleFunctions {
 	 * @param Parser $parser The parser object. Ignored.
 	 * @param PPFrame $frame The parser frame object.
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
-	 * @return array The function output along with relevant parser options.
+	 * @return string The function output along with relevant parser options.
 	 */
-	public function linkpageRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function linkpageRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$text = ParserPower::expand( $frame, $params[0] ?? '' );
 		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'linkpageReplace' ], $text );
 	}
@@ -94,9 +94,9 @@ final class SimpleFunctions {
 	 * @param array $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.
-	 * @return string The function output.
+	 * @return array The function output.
 	 */
-	public function linkpageTagRender( $text, array $attribs, Parser $parser, PPFrame $frame ) {
+	public function linkpageTagRender( ?string $text, array $attribs, Parser $parser, PPFrame $frame ): array {
 		$text = $parser->replaceVariables( $text, $frame );
 
 		if ( $text !== '' ) {
@@ -113,7 +113,7 @@ final class SimpleFunctions {
 	 * @param array $matches The parameters and values together, not yet exploded or trimmed.
 	 * @return string The function output.
 	 */
-	private static function linkpageReplace( $matches ) {
+	private static function linkpageReplace( array $matches ): string {
 		$parts = explode( '|', $matches[1], 2 );
 		return $parts[0];
 	}
@@ -122,9 +122,9 @@ final class SimpleFunctions {
 	 * @param Parser $parser The parser object. Ignored.
 	 * @param PPFrame $frame The parser frame object.
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
-	 * @return array The function output along with relevant parser options.
+	 * @return string The function output along with relevant parser options.
 	 */
-	public function linktextRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function linktextRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$text = ParserPower::expand( $frame, $params[0] ?? '' );
 		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'linktextReplace' ], $text );
 	}
@@ -138,9 +138,9 @@ final class SimpleFunctions {
 	 * @param array $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.
-	 * @return string The function output.
+	 * @return array The function output.
 	 */
-	public function linktextTagRender( $text, array $attribs, Parser $parser, PPFrame $frame ) {
+	public function linktextTagRender( ?string $text, array $attribs, Parser $parser, PPFrame $frame ): array {
 		$text = $parser->replaceVariables( $text, $frame );
 
 		if ( $text !== '' ) {
@@ -156,7 +156,7 @@ final class SimpleFunctions {
 	 * @param array $matches The parameters and values together, not yet exploded or trimmed.
 	 * @return string The function output.
 	 */
-	public function linktextReplace( $matches ) {
+	public function linktextReplace( array $matches ): string {
 		$parts = explode( '|', $matches[1], 2 );
 		if ( count( $parts ) == 2 ) {
 			return $parts[1];
@@ -174,7 +174,7 @@ final class SimpleFunctions {
 	 * @param PPFrame $frame The parser frame object.
 	 * @return string The function output.
 	 */
-	public function escTagRender( $text, array $attribs, Parser $parser, PPFrame $frame ) {
+	public function escTagRender( ?string $text, array $attribs, Parser $parser, PPFrame $frame ): array {
 		return [ ParserPower::escape( $text ), 'markerType' => 'none' ];
 	}
 
@@ -186,7 +186,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function ueifRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function ueifRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$condition = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $condition !== '' ) {
@@ -206,7 +206,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function orRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function orRender( Parser $parser, PPFrame $frame, array $params ): string {
 		foreach ( $params as $param ) {
 			$inValue = ParserPower::expand( $frame, $param );
 
@@ -226,7 +226,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function ueorRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function ueorRender( Parser $parser, PPFrame $frame, array $params ): string {
 		foreach ( $params as $param ) {
 			$inValue = ParserPower::expand( $frame, $param );
 
@@ -247,7 +247,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function ueifeqRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function ueifeqRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$leftValue = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
 		$rightValue = ParserPower::expand( $frame, $params[1] ?? '', ParserPower::UNESCAPE );
 
@@ -268,7 +268,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function tokenRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function tokenRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inValue = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		$token = ParserPower::expand( $frame, $params[1] ?? 'x', ParserPower::UNESCAPE );
@@ -289,7 +289,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function tokenifRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function tokenifRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$inValue = ParserPower::expand( $frame, $params[0] ?? '' );
 
 		if ( $inValue === '' ) {
@@ -315,7 +315,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function ueswitchRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function ueswitchRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$switchKey = isset( $params[0] ) ? ParserPower::expand( $frame, array_shift( $params ), ParserPower::UNESCAPE ) : '';
 
 		if ( count( $params ) === 0 ) {
@@ -373,7 +373,7 @@ final class SimpleFunctions {
 	 * @param array $params The parameters and values together, not yet expanded or trimmed.
 	 * @return string The function output.
 	 */
-	public function followRender( Parser $parser, PPFrame $frame, array $params ) {
+	public function followRender( Parser $parser, PPFrame $frame, array $params ): string {
 		$text = trim( ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE ) );
 
 		$title = Title::newFromText( $text );
@@ -489,7 +489,7 @@ final class SimpleFunctions {
 		return implode( $new_delimiter, $results_array );
 	}
 
-	public function argmapRender( Parser $parser, PPFrame $frame, array $args ) {
+	public function argmapRender( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
 			return '<strong class="error">argmap error: The parameter "formatter" is required.</strong>';
 		}
@@ -565,7 +565,7 @@ final class SimpleFunctions {
 		return implode( $glue, $formatterCalls );
 	}
 
-	public function iargmapRender( Parser $parser, PPFrame $frame, array $args ) {
+	public function iargmapRender( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
 			return '<strong class="error">iargmap error: The parameter "formatter" is required.</strong>';
 		}

--- a/src/SimpleFunctions.php
+++ b/src/SimpleFunctions.php
@@ -97,6 +97,10 @@ final class SimpleFunctions {
 	 * @return array The function output.
 	 */
 	public function linkpageTagRender( ?string $text, array $attribs, Parser $parser, PPFrame $frame ): array {
+		if ( $text === null ) {
+			return [ '', 'markerType' => 'none' ];
+		}
+
 		$text = $parser->replaceVariables( $text, $frame );
 
 		if ( $text !== '' ) {
@@ -141,6 +145,10 @@ final class SimpleFunctions {
 	 * @return array The function output.
 	 */
 	public function linktextTagRender( ?string $text, array $attribs, Parser $parser, PPFrame $frame ): array {
+		if ( $text === null ) {
+			return [ '', 'markerType' => 'none' ];
+		}
+
 		$text = $parser->replaceVariables( $text, $frame );
 
 		if ( $text !== '' ) {

--- a/src/SimpleFunctions.php
+++ b/src/SimpleFunctions.php
@@ -90,7 +90,7 @@ final class SimpleFunctions {
 	 * This removes internal links from, the given wikicode, replacing them with
 	 * the name of the page they would have linked to.
 	 *
-	 * @param string $text The text within the tag function.
+	 * @param ?string $text The text within the tag function.
 	 * @param array $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.
@@ -134,7 +134,7 @@ final class SimpleFunctions {
 	 * This removes internal links from, the given wikicode, replacing them with
 	 * the text that any links would return.
 	 *
-	 * @param string $text The text within the tag function.
+	 * @param ?string $text The text within the tag function.
 	 * @param array $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.
@@ -168,7 +168,7 @@ final class SimpleFunctions {
 	/**
 	 * This function escapes all appropriate characters in the given text and returns the result.
 	 *
-	 * @param string $text The text within the tag function.
+	 * @param ?string $text The text within the tag function.
 	 * @param array $attribs Attributes values of the tag function. Ignored.
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.


### PR DESCRIPTION
Object types have been previously added in #10 for consistency with core extensions, this PR adds types for all function arguments and returned values, as much as possible.

To simplify some function signatures, some functions are slightly changed to only accept `string`, instead of `string|PPNode` or `string|null`.

Also, use optional arguments to merge `arrayTrimSliceUnescape` with `arrayTrimUnescape`: both functions do the same thing but with different implementations.