### PR TITLE
`#lstjoin`: Default input separator as comma

### DIFF
--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -650,7 +650,7 @@ final class ListFunctions {
 		if ( $inList1 === '' ) {
 			$values1 = [];
 		} else {
-			$inSep1 = ParserPower::expand( $frame, $params[1] ?? '', ParserPower::UNESCAPE );
+			$inSep1 = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
 			$inSep1 = $parser->getStripState()->unstripNoWiki( $inSep1 );
 			$values1 = self::arrayTrimUnescape( self::explodeList( $inSep1, $inList1 ) );
 		}
@@ -658,7 +658,7 @@ final class ListFunctions {
 		if ( $inList2 === '' ) {
 			$values2 = [];
 		} else {
-			$inSep2 = ParserPower::expand( $frame, $params[3] ?? '', ParserPower::UNESCAPE );
+			$inSep2 = ParserPower::expand( $frame, $params[3] ?? ',', ParserPower::UNESCAPE );
 			$inSep2 = $parser->getStripState()->unstripNoWiki( $inSep2 );
 			$values2 = self::arrayTrimUnescape( self::explodeList( $inSep2, $inList2 ) );
 		}

--- a/tests/parser/listFunctionsTest.txt
+++ b/tests/parser/listFunctionsTest.txt
@@ -398,9 +398,9 @@ cs desc neg: "-3" / ""
 {{#lstjoin}}
 !! wikitext
 "{{#lstjoin:}}"
-"{{#lstjoin: a  b  c de f   ghi j }}"
+"{{#lstjoin: a, b ,c,d,,e ,f, ,g, h,i,j }}"
 "{{#lstjoin: a; b ;c;d;;e ;f; ;g; h;i;j | ; }}"
-"{{#lstjoin: a; b ;c;d;;e ;f; ;g; h;i;j | ; | k  l  m no p   qrs t }}"
+"{{#lstjoin: a; b ;c;d;;e ;f; ;g; h;i;j | ; | k, l ,m,n,,o ,p, ,q, r,s,t }}"
 "{{#lstjoin: a; b ;c;d;;e ;f; ;g; h;i;j | ; | k; l ;m;n;;o ;p; ;q; r;s;t | ; }}"
 "{{#lstjoin: a; b ;c;d;;e ;f; ;g; h;i;j | ; | k; l ;m;n;;o ;p; ;q; r;s;t | ; | \_; }}"
 !! html/php


### PR DESCRIPTION
## Motivation

ParserPower functions that take a list as argument, also take a separator string for splitting the list. If the separator is an empty string (after evaluation, trimming and unescaping), then it assumes each character is a distinct value.

When unspecified, the input separator defaults to a comma (`,`) with most list parser functions. This is not the case for `#lstjoin`, for which the input separator of both lists (to concatenate) defaults to an empty string, see [the associated test case](https://github.com/wiki-gg-oss/mediawiki-extensions-ParserPower/pull/23/files#diff-405d1700bc10e5466039a472543233f9544685e455b179317140280efba4a09aR397-R414).

## Proposed changes

Make both input separator arguments of the `#lstjoin` parser function default to `,` instead of an empty string.