### PR TITLE
`#listmerge`: Only match new value pairs

### DIFF
--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -2158,6 +2158,8 @@ final class ListFunctions {
 		$valueIndex1,
 		$valueIndex2
 	) {
+		$checkedPairs = [];
+
 		do {
 			$preCount = $count = count( $values );
 
@@ -2169,9 +2171,14 @@ final class ListFunctions {
 					$value2 = $matchParams[$valueIndex2] = $mergeParams[$valueIndex2] = $values[$i2];
 					unset( $values[$i2] );
 
-					$doMerge = call_user_func_array( $applyFunction, $matchParams );
-					$doMerge = $parser->replaceVariables( ParserPower::unescape( trim( $doMerge ) ), $frame );
-					$doMerge = self::decodeBool( $doMerge );
+					if ( isset( $checkedPairs[$value1][$value2] ) ) {
+						$doMerge = $checkedPairs[$value1][$value2];
+					} else {
+						$doMerge = call_user_func_array( $applyFunction, $matchParams );
+						$doMerge = $parser->replaceVariables( ParserPower::unescape( trim( $doMerge ) ), $frame );
+						$doMerge = self::decodeBool( $doMerge );
+						$checkedPairs[$value1][$value2] = $doMerge;
+					}
 
 					if ( $doMerge ) {
 						$value1 = call_user_func_array( $applyFunction, $mergeParams );


### PR DESCRIPTION
## Context

The `#listmerge` parser function merges values of a list 2-by-2. The user must provide a $match$ function (pattern or template) and a $merge$ function (pattern or template). It works as follows:

1. For each value $v_1$ in the list, for each value $v_2$ after $v_1$ in the list:
   - If $match(v_1, v_2)$ then:
     1. Remove $v_2$ from the list.
     2. Replace $v_1$ with $match(v_1, v_2)$ in the list.
2. If the list was modified, start again.

## Issue

If an element has to be merged 3 times, then the $match$ function will have to be evaluated for each value pair 3 times. When the $match$ function does not do (or rely on) any side-effect, then it could only be evaluated once on values that have not been merged (instead of 3). As you'd expect, the longer the list and the more of the same value you have to merge, the greater the number of unnecessary $match$ evaluations.

[For example](https://test.wiki.gg/wiki/User:Derugon#ParserPower_%E2%80%93_#listmerge:_Only_match_new_value_pairs): If we try to only merge the values `b` with `d` in the list `a, b, c, d`:

```html
{{#listmerge:
 | list         = a, b, c, d
 | token1       = @1
 | token2       = @2
 | matchpattern = <esc>{{#ifeq: @1-@2 | b-d | yes }}</esc>
 | mergepattern = @1@2
}}
```

Then we will get the following `matchpattern` evaluations:

- 1st iteration: `a`-`b` (fail), `a`-`c` (fail), `a`-`d` (fail), `b`-`c` (fail), `b`-`d` (success), `a`-`bd` (fail),
- 2nd iteration: `a`-`c` (fail), `bd`-`c` (fail)

The pair `a`-`c` goes though the `matchpattern` twice, once per iteration. If we make the list twice longer, and merge `b` an additional time:

```html
{{#listmerge:
 | list         = a, b, c, d, e, f, g, h
 | token1       = @1
 | token2       = @2
 | matchpattern = <esc>{{#switch: @1-@2 | b-d | bd-c = yes }}</esc>
 | mergepattern = @1@2
}}
```

Then the `matchpattern` is evaluated 55 times, while only 30 of these would be necessary.

## Proposed changes

Assume the match function is pure:
- if it failed once with a pair $(v_1, v_2)$, then it will always fail with any pair $(v'_1, v'_2)$ of values such that $v_1 = v'_1$ and $v_2 = v'_2$ once evaluated and trimmed, and
- if it succeeded once with a pair $(v_1, v_2)$, then it will always succeed with any pair $(v'_1, v'_2)$ of values such that $v_1 = v'_1$ and $v_2 = v'_2$ once evaluated and trimmed.

Also change the `ListFunctions::iterativeListMerge` function to not create new arrays each iteration and reindex arrays each time a value is read.

## Breaking changes

If the match function does side-effects or relies on side-effects from the merge function, then:
- The evaluation order of (unique) matches and merges is unchanged. All value pairs are checked at most once per iteration, in the same order as before.
- On subsequent iterations, a same pair of values for which the match failed will not never be matched again in the next iterations.
- If a duplicate is in the initial list or generated by a merge, it will still be kept and merged as before, but it will not be matched with any other value (except itself and newly merged values).