### PR TITLE
`#lstmap`: Evaluate token and pattern like `#listmap`

### DIFF
--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1950,7 +1950,7 @@ final class ListFunctions {
 
 		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
 		$token = ParserPower::expand( $frame, $params[2] ?? 'x', ParserPower::NO_VARS | ParserPower::UNESCAPE );
-		$pattern = $params[3] ?? 'x';
+		$pattern = ParserPower::expand( $frame, $params[3] ?? 'x' );
 		$outSep = ParserPower::expand( $frame, $params[4] ?? ',\_', ParserPower::UNESCAPE );
 		$sortMode = ParserPower::expand( $frame, $params[5] ?? '' );
 		$sortOptions = ParserPower::expand( $frame, $params[6] ?? '' );

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1949,7 +1949,7 @@ final class ListFunctions {
 		}
 
 		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$token = ParserPower::expand( $frame, $params[2] ?? 'x', ParserPower::NO_VARS | ParserPower::UNESCAPE );
+		$token = ParserPower::expand( $frame, $params[2] ?? 'x', ParserPower::UNESCAPE );
 		$pattern = ParserPower::expand( $frame, $params[3] ?? 'x' );
 		$outSep = ParserPower::expand( $frame, $params[4] ?? ',\_', ParserPower::UNESCAPE );
 		$sortMode = ParserPower::expand( $frame, $params[5] ?? '' );


### PR DESCRIPTION
## Context

ParserPower list functions with named arguments accept a `token` and a `pattern` arguments. Whatever the function does in practice, the tokens and patterns work the same way:

1. Initially, the `token` and `pattern` arguments are both evaluated, trimmed, then unescaped.
2. Each iteration, `token` occurrences in the `pattern` are replaced with a given value, then the result is evaluated again.

Unlike with the Loops or PageForms extensions, this allows to dynamically change the tokens and patterns depending on the frame and context.

For example, suppose we have a `{{format links}}` template, that takes a comma-separated list of titles, and returns a list of links, i.e. `{{format links|x, y, z}}` yields `[[x]], [[y]], [[z]]`:
```html
{{#listmap:
 | list    = {{{1}}}
 | token   = @
 | pattern = [[@]]
}}
```
Now if we want to let the user specify their own token and pattern. We can change the token and pattern depending on the frame arguments:
```html
{{#listmap:
 | list    = {{{1}}}
 | token   = {{#or: {{{token|}}} | @ }}
 | pattern = {{#or: {{{pattern|}}} | [[@]] }}
}}
```
In case there is some logic to apply within the pattern or token, the wikitext syntax can be escaped, and will be evaluated once per iteration (after being unescaped). For example:
```html
{{#listmap:
 | list    = {{{1}}}
 | token   = {{#or: {{{token|}}} | @ }}
 | pattern = {{#or: {{{pattern|}}} | <esc>{{#ifeq: {{ns:@}} | File | [[:@]] | [[@]] }}</esc> }}
}}
```

## Issue

The `#lstmap` function takes a token and pattern as unnamed arguments, and works as following:

1. Initially, the `token` and `pattern` arguments are both trimmed then unescaped.
2. Each iteration, `token` occurrences in the `pattern` are replaced with a given value, then the result is evaluated.

Consequently, any wikitext syntax will only be evaluated after the token replacement. This means the last 2 previous examples do not work with `#lstmap`:
```html
{{#lstmap: {{{1}}} | , | {{#or: {{{token|}}} | @ }} | {{#or: {{{pattern|}}} | [[@]] }} }}
```
- the raw string `{{#or: {{{token|}}} | @ }}` is used as token, and
- the pattern `{{#or: {{{pattern|}}} | [[@]] }}` is used as pattern (and evaluated once per loop iteration).

## Proposed changes

Make `#lstmap` evaluate its token and pattern arguments directly as wikitext, before trimming, unescaping, and iterating over the list.

This would make `{{#lstmap: <list> | <insep> | <token> | <pattern> | <outsep> | <sortmode> | <sortoptions> }}` work exactly the same way as
```
{{#listmap:
 | list        = <list>
 | insep       = <insep>
 | token       = <token>
 | pattern     = <pattern>
 | outsep      = <outsep>
 | sortmode    = <sortmode>
 | sortoptions = <sortoptions>
}}
```

## Breaking changes

These changes would break any use of `#lstmap` where the token or pattern argument contains unescaped wikitext variable syntax (i.e. parser functions, tags).

In these cases, `{{#lstmap: list | insep | token | pattern | outsep }}` can be replaced by:
- `{{#lstmap: list | insep | <esc>token</esc> | <esc>pattern</esc> | outsep }}`, see [escape sequences](https://support.wiki.gg/wiki/ParserPower/escape_sequences#Escape_sequences_in_ParserPower) if the token is small enough,
- `{{#arraymap: list | insep | token | pattern | outsep }}` if you prefer not using the escaping syntax.
