### PR TITLE
List functions: Evaluate arguments more lazily

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Add new entries to the top of the 1.x.x-NEXT section.
 
 ### 1.x.x-NEXT (YYYY-MM-DD)
 * Added `outconj` optional parameter to `#listmap`. If defined, its value is unescaped then trimmed, and will be used as delimiter for the last 2 output list values.
+* List functions now evaluate most of their parameters lazily. Parameter evaluation order may have changed, and side effects may no longer be applied inside unused parameters.
 * …
 
 ### 1.6.1 (2025-04-27)

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -103,17 +103,10 @@ class ListFilterFunction implements ParserFunction {
 					$operation = new TemplateOperation( $parser, $frame, $template );
 				} else {
 					$indexToken = $params->get( 'indextoken' );
-					$token = $params->get( 'token' );
-					$tokenSep = $params->get( 'tokensep' );
+					$tokenSep = $fieldSep !== '' ? $params->get( 'tokensep' ) : '';
 					$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
+					$tokens = ListUtils::explodeToken( $tokenSep, $params->get( 'token' ) );
 					$pattern = $params->get( 'pattern' );
-
-					if ( $fieldSep !== '' ) {
-						$tokens = ListUtils::explodeToken( $tokenSep, $token );
-					} else {
-						$tokens = [ $token ];
-					}
-
 					$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 				}
 			}

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -78,7 +78,6 @@ class ListFilterFunction implements ParserFunction {
 		$tokenSep = $params->get( 'tokensep' );
 		$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep' );
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
@@ -120,6 +119,7 @@ class ListFilterFunction implements ParserFunction {
 		}
 
 		$count = count( $outValues );
+		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $outValues, $outSep );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
 

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -71,48 +71,55 @@ class ListFilterFunction implements ParserFunction {
 		}
 
 		$keepValues = $params->get( 'keep' );
-		$keepSep = $params->get( 'keepsep' );
-		$keepCS = ListUtils::decodeBool( $params->get( 'keepcs' ) );
-		$removeValues = $params->get( 'remove' );
-		$removeSep = $params->get( 'removesep' );
-		$removeCS = ListUtils::decodeBool( $params->get( 'removecs' ) );
-		$template = $params->get( 'template' );
-		$fieldSep = $params->get( 'fieldsep' );
-		$indexToken = $params->get( 'indextoken' );
-		$token = $params->get( 'token' );
-		$tokenSep = $params->get( 'tokensep' );
-		$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
-		$pattern = $params->get( 'pattern' );
 
 		if ( $keepValues !== '' ) {
+			$keepSep = $params->get( 'keepsep' );
 			if ( $keepSep !== '' ) {
 				$keepValues = ListUtils::explode( $keepSep, $keepValues );
 			} else {
 				$keepValues = [ ParserPower::unescape( $keepValues ) ];
 			}
 
+			$keepCS = ListUtils::decodeBool( $params->get( 'keepcs' ) );
 			$operation = new ListInclusionOperation( $keepValues, '', 'remove', $keepCS );
-		} elseif ( $removeValues !== '' ) {
-			if ( $removeSep !== '' ) {
-				$removeValues = ListUtils::explode( $removeSep, $removeValues );
-			} else {
-				$removeValues = [ ParserPower::unescape( $removeValues ) ];
-			}
-
-			$operation = new ListInclusionOperation( $removeValues, 'remove', '', $removeCS );
-		} elseif ( $template !== '' ) {
-			$operation = new TemplateOperation( $parser, $frame, $template );
 		} else {
-			if ( $fieldSep !== '' ) {
-				$tokens = ListUtils::explodeToken( $tokenSep, $token );
-			} else {
-				$tokens = [ $token ];
-			}
+			$removeValues = $params->get( 'remove' );
 
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+			if ( $removeValues !== '' ) {
+				$removeSep = $params->get( 'removesep' );
+				if ( $removeSep !== '' ) {
+					$removeValues = ListUtils::explode( $removeSep, $removeValues );
+				} else {
+					$removeValues = [ ParserPower::unescape( $removeValues ) ];
+				}
+
+				$removeCS = ListUtils::decodeBool( $params->get( 'removecs' ) );
+				$operation = new ListInclusionOperation( $removeValues, 'remove', '', $removeCS );
+			} else {
+				$template = $params->get( 'template' );
+				$fieldSep = $params->get( 'fieldsep' );
+
+				if ( $template !== '' ) {
+					$operation = new TemplateOperation( $parser, $frame, $template );
+				} else {
+					$indexToken = $params->get( 'indextoken' );
+					$token = $params->get( 'token' );
+					$tokenSep = $params->get( 'tokensep' );
+					$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
+					$pattern = $params->get( 'pattern' );
+
+					if ( $fieldSep !== '' ) {
+						$tokens = ListUtils::explodeToken( $tokenSep, $token );
+					} else {
+						$tokens = [ $token ];
+					}
+
+					$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+				}
+			}
 		}
 
-		$outValues = $this->filterList( $operation, $inValues, $fieldSep );
+		$outValues = $this->filterList( $operation, $inValues, $fieldSep ?? '' );
 
 		if ( count( $outValues ) === 0 ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -57,12 +57,7 @@ class ListFilterFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
-		}
-
-		$inSep = $params->get( 'insep' );
+		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -78,9 +78,6 @@ class ListFilterFunction implements ParserFunction {
 		$tokenSep = $params->get( 'tokensep' );
 		$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
 		$pattern = $params->get( 'pattern' );
-		$countToken = $params->get( 'counttoken' );
-		$intro = $params->get( 'intro' );
-		$outro = $params->get( 'outro' );
 
 		$inValues = ListUtils::explode( $inSep, $inList );
 
@@ -121,6 +118,10 @@ class ListFilterFunction implements ParserFunction {
 		$count = count( $outValues );
 		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $outValues, $outSep );
+
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -62,6 +62,14 @@ class ListFilterFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
+		$inSep = $params->get( 'insep' );
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+		}
+
 		$keepValues = $params->get( 'keep' );
 		$keepSep = $params->get( 'keepsep' );
 		$keepCS = ListUtils::decodeBool( $params->get( 'keepcs' ) );
@@ -69,16 +77,12 @@ class ListFilterFunction implements ParserFunction {
 		$removeSep = $params->get( 'removesep' );
 		$removeCS = ListUtils::decodeBool( $params->get( 'removecs' ) );
 		$template = $params->get( 'template' );
-		$inSep = $params->get( 'insep' );
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
 		$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
 		$pattern = $params->get( 'pattern' );
-
-		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( $keepValues !== '' ) {
 			if ( $keepSep !== '' ) {

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -57,10 +57,9 @@ class ListFilterFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default' );
 
 		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$keepValues = $params->get( 'keep' );
@@ -112,7 +111,7 @@ class ListFilterFunction implements ParserFunction {
 		$outValues = $this->filterList( $operation, $inValues, $fieldSep );
 
 		if ( count( $outValues ) === 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$count = count( $outValues );

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -59,6 +59,10 @@ class ListFilterFunction implements ParserFunction {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 
+		if ( $inList === '' ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+		}
+
 		$keepValues = $params->get( 'keep' );
 		$keepSep = $params->get( 'keepsep' );
 		$keepCS = ListUtils::decodeBool( $params->get( 'keepcs' ) );
@@ -78,10 +82,6 @@ class ListFilterFunction implements ParserFunction {
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
-		}
 
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -77,8 +77,6 @@ class ListMapFunction implements ParserFunction {
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep' );
-		$outConj = $params->get( 'outconj', [ 'default' => $outSep ] );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
 		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
@@ -139,6 +137,8 @@ class ListMapFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
 
+		$outSep = $count > 2 ? $params->get( 'outsep' ) : '';
+		$outConj = $count > 1 ? $params->get( $params->isDefined( 'outconj' ) ? 'outconj' : 'outsep' ) : '';
 		if ( $outConj !== $outSep ) {
 			$outConj = ' ' . trim( $outConj ) . ' ';
 		}

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -68,9 +68,15 @@ class ListMapFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
-		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+		}
+
+		$template = $params->get( 'template' );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
@@ -81,8 +87,6 @@ class ListMapFunction implements ParserFunction {
 		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
 
 		$sorter = new ListSorter( $sortOptions );
-
-		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( $duplicates & ListUtils::DUPLICATES_PRESTRIP ) {
 			$inValues = array_unique( $inValues );

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -65,6 +65,10 @@ class ListMapFunction implements ParserFunction {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 
+		if ( $inList === '' ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+		}
+
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
@@ -81,10 +85,6 @@ class ListMapFunction implements ParserFunction {
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
-		}
 
 		$sorter = new ListSorter( $sortOptions );
 

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -78,10 +78,6 @@ class ListMapFunction implements ParserFunction {
 
 		$template = $params->get( 'template' );
 		$fieldSep = $params->get( 'fieldsep' );
-		$indexToken = $params->get( 'indextoken' );
-		$token = $params->get( 'token' );
-		$tokenSep = $params->get( 'tokensep' );
-		$pattern = $params->get( 'pattern' );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
 		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
@@ -104,6 +100,11 @@ class ListMapFunction implements ParserFunction {
 				$outValues = $sorter->sort( $outValues );
 			}
 		} else {
+			$indexToken = $params->get( 'indextoken' );
+			$token = $params->get( 'token' );
+			$tokenSep = $params->get( 'tokensep' );
+			$pattern = $params->get( 'pattern' );
+
 			if (
 				( $indexToken !== '' && $sortMode & ListUtils::SORTMODE_COMPAT ) ||
 				$sortMode & ListUtils::SORTMODE_PRE

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -78,11 +78,12 @@ class ListMapFunction implements ParserFunction {
 
 		$template = $params->get( 'template' );
 		$fieldSep = $params->get( 'fieldsep' );
-		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
-		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
-		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
 
+		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
+		$sortOptions = $sortMode > 0 ? ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) ) : 0;
 		$sorter = new ListSorter( $sortOptions );
+
+		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
 
 		if ( $duplicates & ListUtils::DUPLICATES_PRESTRIP ) {
 			$inValues = array_unique( $inValues );

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -63,10 +63,9 @@ class ListMapFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default' );
 
 		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$template = $params->get( 'template' );
@@ -131,7 +130,7 @@ class ListMapFunction implements ParserFunction {
 
 		$count = count( $outValues );
 		if ( $count === 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$outSep = $count > 2 ? $params->get( 'outsep' ) : '';

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -63,12 +63,7 @@ class ListMapFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
-		}
-
-		$inSep = $params->get( 'insep' );
+		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -80,9 +80,6 @@ class ListMapFunction implements ParserFunction {
 		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
 		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
-		$countToken = $params->get( 'counttoken' );
-		$intro = $params->get( 'intro' );
-		$outro = $params->get( 'outro' );
 
 		$sorter = new ListSorter( $sortOptions );
 
@@ -142,9 +139,13 @@ class ListMapFunction implements ParserFunction {
 		if ( $outConj !== $outSep ) {
 			$outConj = ' ' . trim( $outConj ) . ' ';
 		}
-
 		$outList = ListUtils::implode( $outValues, $outSep, $outConj );
+
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
+
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -102,8 +102,8 @@ class ListMapFunction implements ParserFunction {
 			}
 		} else {
 			$indexToken = $params->get( 'indextoken' );
-			$token = $params->get( 'token' );
-			$tokenSep = $params->get( 'tokensep' );
+			$tokenSep = $fieldSep !== '' ? $params->get( 'tokensep' ) : '';
+			$tokens = ListUtils::explodeToken( $tokenSep, $params->get( 'token' ) );
 			$pattern = $params->get( 'pattern' );
 
 			if (
@@ -111,12 +111,6 @@ class ListMapFunction implements ParserFunction {
 				$sortMode & ListUtils::SORTMODE_PRE
 			) {
 				$inValues = $sorter->sort( $inValues );
-			}
-
-			if ( $fieldSep !== '' ) {
-				$tokens = ListUtils::explodeToken( $tokenSep, $token );
-			} else {
-				$tokens = [ $token ];
 			}
 
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -134,9 +134,6 @@ class ListMergeFunction implements ParserFunction {
 		$outSep = $params->get( 'outsep' );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
-		$countToken = $params->get( 'counttoken' );
-		$intro = $params->get( 'intro' );
-		$outro = $params->get( 'outro' );
 
 		$sorter = new ListSorter( $sortOptions );
 
@@ -178,7 +175,12 @@ class ListMergeFunction implements ParserFunction {
 
 		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $outValues, $outSep );
+
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
+
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -131,12 +131,6 @@ class ListMergeFunction implements ParserFunction {
 		$matchTemplate = $params->get( 'matchtemplate' );
 		$mergeTemplate = $params->get( 'mergetemplate' );
 		$fieldSep = $params->get( 'fieldsep' );
-		$token1 = $params->get( 'token1' );
-		$token2 = $params->get( 'token2' );
-		$tokenSep = $params->get( 'tokensep' );
-		$matchPattern = $params->get( 'matchpattern' );
-		$mergePattern = $params->get( 'mergepattern' );
-		$outSep = $params->get( 'outsep' );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
 
@@ -150,6 +144,10 @@ class ListMergeFunction implements ParserFunction {
 			$matchOperation = new TemplateOperation( $parser, $frame, $matchTemplate );
 			$mergeOperation = new TemplateOperation( $parser, $frame, $mergeTemplate );
 		} else {
+			$token1 = $params->get( 'token1' );
+			$token2 = $params->get( 'token2' );
+			$tokenSep = $params->get( 'tokensep' );
+
 			if ( $fieldSep !== '' ) {
 				$tokens1 = ListUtils::explodeToken( $tokenSep, $token1 );
 				$tokens2 = ListUtils::explodeToken( $tokenSep, $token2 );
@@ -160,6 +158,8 @@ class ListMergeFunction implements ParserFunction {
 			$tokens = [ ...$tokens1, ...$tokens2 ];
 			$fieldOffset = count( $tokens1 );
 
+			$matchPattern = $params->get( 'matchpattern' );
+			$mergePattern = $params->get( 'mergepattern' );
 			$matchOperation = new PatternOperation( $parser, $frame, $matchPattern, $tokens );
 			$mergeOperation = new PatternOperation( $parser, $frame, $mergePattern, $tokens );
 

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -115,12 +115,7 @@ class ListMergeFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
-		}
-
-		$inSep = $params->get( 'insep' );
+		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -117,6 +117,10 @@ class ListMergeFunction implements ParserFunction {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 
+		if ( $inList === '' ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+		}
+
 		$matchTemplate = $params->get( 'matchtemplate' );
 		$mergeTemplate = $params->get( 'mergetemplate' );
 		$inSep = $params->get( 'insep' );
@@ -133,10 +137,6 @@ class ListMergeFunction implements ParserFunction {
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
-		}
 
 		$sorter = new ListSorter( $sortOptions );
 

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -115,10 +115,9 @@ class ListMergeFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default' );
 
 		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$matchTemplate = $params->get( 'matchtemplate' );
@@ -170,7 +169,7 @@ class ListMergeFunction implements ParserFunction {
 
 		$count = count( $outValues );
 		if ( $count === 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -171,12 +171,14 @@ class ListMergeFunction implements ParserFunction {
 			$outValues = $sorter->sort( $outValues );
 		}
 
-		if ( count( $outValues ) === 0 ) {
+		$count = count( $outValues );
+		if ( $count === 0 ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
 
-		$count = count( $outValues );
-		$outList = ListUtils::applyIntroAndOutro( $intro, implode( $outSep, $outValues ), $outro, $countToken, $count );
+		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
+		$outList = ListUtils::implode( $outValues, $outSep );
+		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -120,10 +120,16 @@ class ListMergeFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
-		$matchTemplate = $params->get( 'matchtemplate' );
-		$mergeTemplate = $params->get( 'mergetemplate' );
 		$inSep = $params->get( 'insep' );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+		}
+
+		$matchTemplate = $params->get( 'matchtemplate' );
+		$mergeTemplate = $params->get( 'mergetemplate' );
 		$fieldSep = $params->get( 'fieldsep' );
 		$token1 = $params->get( 'token1' );
 		$token2 = $params->get( 'token2' );
@@ -135,8 +141,6 @@ class ListMergeFunction implements ParserFunction {
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
 
 		$sorter = new ListSorter( $sortOptions );
-
-		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( $sortMode & ListUtils::SORTMODE_PRE ) {
 			$inValues = $sorter->sort( $inValues );

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -131,9 +131,9 @@ class ListMergeFunction implements ParserFunction {
 		$matchTemplate = $params->get( 'matchtemplate' );
 		$mergeTemplate = $params->get( 'mergetemplate' );
 		$fieldSep = $params->get( 'fieldsep' );
-		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
-		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
 
+		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
+		$sortOptions = $sortMode > 0 ? ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) ) : 0;
 		$sorter = new ListSorter( $sortOptions );
 
 		if ( $sortMode & ListUtils::SORTMODE_PRE ) {

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -144,17 +144,9 @@ class ListMergeFunction implements ParserFunction {
 			$matchOperation = new TemplateOperation( $parser, $frame, $matchTemplate );
 			$mergeOperation = new TemplateOperation( $parser, $frame, $mergeTemplate );
 		} else {
-			$token1 = $params->get( 'token1' );
-			$token2 = $params->get( 'token2' );
-			$tokenSep = $params->get( 'tokensep' );
-
-			if ( $fieldSep !== '' ) {
-				$tokens1 = ListUtils::explodeToken( $tokenSep, $token1 );
-				$tokens2 = ListUtils::explodeToken( $tokenSep, $token2 );
-			} else {
-				$tokens1 = [ $token1 ];
-				$tokens2 = [ $token2 ];
-			}
+			$tokenSep = $fieldSep !== '' ? $params->get( 'tokensep' ) : '';
+			$tokens1 = ListUtils::explodeToken( $tokenSep, $params->get( 'token1' ) );
+			$tokens2 = ListUtils::explodeToken( $tokenSep, $params->get( 'token2' ) );
 			$tokens = [ ...$tokens1, ...$tokens2 ];
 			$fieldOffset = count( $tokens1 );
 

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -73,10 +73,9 @@ class ListSortFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default' );
 
 		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$template = $params->get( 'template' );
@@ -130,7 +129,7 @@ class ListSortFunction implements ParserFunction {
 		}
 
 		if ( count( $values ) === 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$count = count( $values );

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -89,12 +89,8 @@ class ListSortFunction implements ParserFunction {
 		$template = $params->get( 'template' );
 		$sortOptions = $params->get( 'sortoptions' );
 		$subsort = ListUtils::decodeBool( $params->get( 'subsort' ) );
-		$subsortOptions = ListUtils::decodeSortOptions( $params->get( 'subsortoptions' ) );
+		$subsortOptions = $subsort ? ListUtils::decodeSortOptions( $params->get( 'subsortoptions' ) ) : null;
 		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
-
-		if ( !$subsort ) {
-			$subsortOptions = null;
-		}
 
 		if ( $duplicates & ListUtils::DUPLICATES_STRIP ) {
 			$values = array_unique( $values );

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -73,12 +73,7 @@ class ListSortFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
-		}
-
-		$inSep = $params->get( 'insep' );
+		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$values = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -112,14 +112,8 @@ class ListSortFunction implements ParserFunction {
 
 			if ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) {
 				$fieldSep = $params->get( 'fieldsep' );
-				$tokenSep = $params->get( 'tokensep' );
-
-				if ( $fieldSep !== '' ) {
-					$tokens = ListUtils::explodeToken( $tokenSep, $token );
-				} else {
-					$tokens = [ $token ];
-				}
-
+				$tokenSep = $fieldSep !== '' ? $params->get( 'tokensep' ) : '';
+				$tokens = ListUtils::explodeToken( $tokenSep, $token );
 				$sortOptions = ListUtils::decodeSortOptions( $sortOptions, ListSorter::NUMERIC );
 				$sorter = new ListSorter( $sortOptions, $subsortOptions );
 				$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -75,6 +75,10 @@ class ListSortFunction implements ParserFunction {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 
+		if ( $inList === '' ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+		}
+
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
@@ -91,10 +95,6 @@ class ListSortFunction implements ParserFunction {
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
-		}
 
 		if ( !$subsort ) {
 			$subsortOptions = null;

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -91,9 +91,6 @@ class ListSortFunction implements ParserFunction {
 		$subsort = ListUtils::decodeBool( $params->get( 'subsort' ) );
 		$subsortOptions = ListUtils::decodeSortOptions( $params->get( 'subsortoptions' ) );
 		$duplicates = ListUtils::decodeDuplicates( $params->get( 'duplicates' ) );
-		$countToken = $params->get( 'counttoken' );
-		$intro = $params->get( 'intro' );
-		$outro = $params->get( 'outro' );
 
 		if ( !$subsort ) {
 			$subsortOptions = null;
@@ -139,7 +136,12 @@ class ListSortFunction implements ParserFunction {
 		$count = count( $values );
 		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $values, $outSep );
+
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
+
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -87,11 +87,6 @@ class ListSortFunction implements ParserFunction {
 		}
 
 		$template = $params->get( 'template' );
-		$fieldSep = $params->get( 'fieldsep' );
-		$indexToken = $params->get( 'indextoken' );
-		$token = $params->get( 'token' );
-		$tokenSep = $params->get( 'tokensep' );
-		$pattern = $params->get( 'pattern' );
 		$sortOptions = $params->get( 'sortoptions' );
 		$subsort = ListUtils::decodeBool( $params->get( 'subsort' ) );
 		$subsortOptions = ListUtils::decodeSortOptions( $params->get( 'subsortoptions' ) );
@@ -106,6 +101,7 @@ class ListSortFunction implements ParserFunction {
 		}
 
 		if ( $template !== '' ) {
+			$fieldSep = $params->get( 'fieldsep' );
 			$sortOptions = ListUtils::decodeSortOptions( $sortOptions, ListSorter::NUMERIC );
 			$sorter = new ListSorter( $sortOptions, $subsortOptions );
 			$operation = new TemplateOperation( $parser, $frame, $template );
@@ -113,24 +109,33 @@ class ListSortFunction implements ParserFunction {
 			$pairedValues = $this->generateSortKeys( $operation, $values, $fieldSep );
 			$sorter->sortPairs( $pairedValues );
 			$values = $this->discardSortKeys( $pairedValues );
-		} elseif ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) {
-			if ( $fieldSep !== '' ) {
-				$tokens = ListUtils::explodeToken( $tokenSep, $token );
-			} else {
-				$tokens = [ $token ];
-			}
-
-			$sortOptions = ListUtils::decodeSortOptions( $sortOptions, ListSorter::NUMERIC );
-			$sorter = new ListSorter( $sortOptions, $subsortOptions );
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
-
-			$pairedValues = $this->generateSortKeys( $operation, $values, $fieldSep );
-			$sorter->sortPairs( $pairedValues );
-			$values = $this->discardSortKeys( $pairedValues );
 		} else {
-			$sortOptions = ListUtils::decodeSortOptions( $sortOptions );
-			$sorter = new ListSorter( $sortOptions );
-			$values = $sorter->sort( $values );
+			$indexToken = $params->get( 'indextoken' );
+			$token = $params->get( 'token' );
+			$pattern = $params->get( 'pattern' );
+
+			if ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) {
+				$fieldSep = $params->get( 'fieldsep' );
+				$tokenSep = $params->get( 'tokensep' );
+
+				if ( $fieldSep !== '' ) {
+					$tokens = ListUtils::explodeToken( $tokenSep, $token );
+				} else {
+					$tokens = [ $token ];
+				}
+
+				$sortOptions = ListUtils::decodeSortOptions( $sortOptions, ListSorter::NUMERIC );
+				$sorter = new ListSorter( $sortOptions, $subsortOptions );
+				$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+
+				$pairedValues = $this->generateSortKeys( $operation, $values, $fieldSep );
+				$sorter->sortPairs( $pairedValues );
+				$values = $this->discardSortKeys( $pairedValues );
+			} else {
+				$sortOptions = ListUtils::decodeSortOptions( $sortOptions );
+				$sorter = new ListSorter( $sortOptions );
+				$values = $sorter->sort( $values );
+			}
 		}
 
 		if ( count( $values ) === 0 ) {

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -87,7 +87,6 @@ class ListSortFunction implements ParserFunction {
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep' );
 		$sortOptions = $params->get( 'sortoptions' );
 		$subsort = ListUtils::decodeBool( $params->get( 'subsort' ) );
 		$subsortOptions = ListUtils::decodeSortOptions( $params->get( 'subsortoptions' ) );
@@ -138,6 +137,7 @@ class ListSortFunction implements ParserFunction {
 		}
 
 		$count = count( $values );
+		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $values, $outSep );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -78,9 +78,15 @@ class ListSortFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
-		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$values = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $values ) === 0 ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+		}
+
+		$template = $params->get( 'template' );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
@@ -95,7 +101,6 @@ class ListSortFunction implements ParserFunction {
 			$subsortOptions = null;
 		}
 
-		$values = ListUtils::explode( $inSep, $inList );
 		if ( $duplicates & ListUtils::DUPLICATES_STRIP ) {
 			$values = array_unique( $values );
 		}

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -89,28 +89,33 @@ class ListUniqueFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
-		$uniqueCS = ListUtils::decodeBool( $params->get( 'uniquecs' ) );
 		$template = $params->get( 'template' );
-		$fieldSep = $params->get( 'fieldsep' );
-		$indexToken = $params->get( 'indextoken' );
-		$token = $params->get( 'token' );
-		$tokenSep = $params->get( 'tokensep' );
-		$pattern = $params->get( 'pattern' );
-
-		if ( $fieldSep !== '' ) {
-			$tokens = ListUtils::explodeToken( $tokenSep, $token );
-		} else {
-			$tokens = [ $token ];
-		}
 
 		if ( $template !== '' ) {
+			$fieldSep = $params->get( 'fieldsep' );
 			$operation = new TemplateOperation( $parser, $frame, $template );
 			$outValues = $this->reduceToUniqueValuesByKey( $operation, $inValues, $fieldSep );
-		} elseif ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) {
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
-			$outValues = $this->reduceToUniqueValuesByKey( $operation, $inValues, $fieldSep );
 		} else {
-			$outValues = $this->reduceToUniqueValues( $inValues, $uniqueCS );
+			$indexToken = $params->get( 'indextoken' );
+			$token = $params->get( 'token' );
+			$pattern = $params->get( 'pattern' );
+
+			if ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) {
+				$fieldSep = $params->get( 'fieldsep' );
+				$tokenSep = $params->get( 'tokensep' );
+
+				if ( $fieldSep !== '' ) {
+					$tokens = ListUtils::explodeToken( $tokenSep, $token );
+				} else {
+					$tokens = [ $token ];
+				}
+
+				$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+				$outValues = $this->reduceToUniqueValuesByKey( $operation, $inValues, $fieldSep );
+			} else {
+				$uniqueCS = ListUtils::decodeBool( $params->get( 'uniquecs' ) );
+				$outValues = $this->reduceToUniqueValues( $inValues, $uniqueCS );
+			}
 		}
 
 		$count = count( $outValues );

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -79,6 +79,10 @@ class ListUniqueFunction implements ParserFunction {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 
+		if ( $inList === '' ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+		}
+
 		$uniqueCS = ListUtils::decodeBool( $params->get( 'uniquecs' ) );
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
@@ -91,10 +95,6 @@ class ListUniqueFunction implements ParserFunction {
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
-		}
 
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -82,16 +82,20 @@ class ListUniqueFunction implements ParserFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
+		$inSep = $params->get( 'insep' );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+		}
+
 		$uniqueCS = ListUtils::decodeBool( $params->get( 'uniquecs' ) );
 		$template = $params->get( 'template' );
-		$inSep = $params->get( 'insep' );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-
-		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( $fieldSep !== '' ) {
 			$tokens = ListUtils::explodeToken( $tokenSep, $token );

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -91,9 +91,6 @@ class ListUniqueFunction implements ParserFunction {
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$countToken = $params->get( 'counttoken' );
-		$intro = $params->get( 'intro' );
-		$outro = $params->get( 'outro' );
 
 		$inValues = ListUtils::explode( $inSep, $inList );
 
@@ -116,7 +113,12 @@ class ListUniqueFunction implements ParserFunction {
 		$count = count( $outValues );
 		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $outValues, $outSep );
+
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
+
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -91,7 +91,6 @@ class ListUniqueFunction implements ParserFunction {
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep' );
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
@@ -115,6 +114,7 @@ class ListUniqueFunction implements ParserFunction {
 		}
 
 		$count = count( $outValues );
+		$outSep = $count > 1 ? $params->get( 'outsep' ) : '';
 		$outList = ListUtils::implode( $outValues, $outSep );
 		$outList = ListUtils::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -77,10 +77,9 @@ class ListUniqueFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default' );
 
 		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
 		$uniqueCS = ListUtils::decodeBool( $params->get( 'uniquecs' ) );

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -102,14 +102,8 @@ class ListUniqueFunction implements ParserFunction {
 
 			if ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) {
 				$fieldSep = $params->get( 'fieldsep' );
-				$tokenSep = $params->get( 'tokensep' );
-
-				if ( $fieldSep !== '' ) {
-					$tokens = ListUtils::explodeToken( $tokenSep, $token );
-				} else {
-					$tokens = [ $token ];
-				}
-
+				$tokenSep = $fieldSep !== '' ? $params->get( 'tokensep' ) : '';
+				$tokens = ListUtils::explodeToken( $tokenSep, $token );
 				$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 				$outValues = $this->reduceToUniqueValuesByKey( $operation, $inValues, $fieldSep );
 			} else {

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -77,12 +77,7 @@ class ListUniqueFunction implements ParserFunction {
 		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-
-		if ( $inList === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
-		}
-
-		$inSep = $params->get( 'insep' );
+		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
 		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( count( $inValues ) === 0 ) {

--- a/src/Function/List/LstAppFunction.php
+++ b/src/Function/List/LstAppFunction.php
@@ -42,11 +42,12 @@ final class LstAppFunction implements ParserFunction {
 
 		$sep = $params->get( 1 );
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
-
 		$values = ListUtils::explode( $sep, $list );
+
 		if ( $value !== '' ) {
 			$values[] = $value;
 		}
+
 		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $sep ) );
 	}
 }

--- a/src/Function/List/LstAppFunction.php
+++ b/src/Function/List/LstAppFunction.php
@@ -34,14 +34,9 @@ final class LstAppFunction implements ParserFunction {
 		] );
 
 		$list = $params->get( 0 );
-		$value = $params->get( 2 );
-
-		if ( $list === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $value );
-		}
-
-		$sep = $params->get( 1 );
+		$sep = $list !== '' ? $params->get( 1 ) : '';
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
+		$value = $params->get( 2 );
 		$values = ListUtils::explode( $sep, $list );
 
 		if ( $value !== '' ) {

--- a/src/Function/List/LstCntFunction.php
+++ b/src/Function/List/LstCntFunction.php
@@ -32,11 +32,7 @@ final class LstCntFunction implements ParserFunction {
 		] );
 
 		$list = $params->get( 0 );
-		if ( $list === '' ) {
-			return '0';
-		}
-
-		$sep = $params->get( 1 );
+		$sep = $list !== '' ? $params->get( 1 ) : '';
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 
 		return (string)count( ListUtils::explode( $sep, $list ) );

--- a/src/Function/List/LstCntUniqFunction.php
+++ b/src/Function/List/LstCntUniqFunction.php
@@ -32,16 +32,22 @@ final class LstCntUniqFunction extends ListUniqueFunction {
 		] );
 
 		$inList = $params->get( 0 );
+
 		if ( $inList === '' ) {
 			return '0';
 		}
 
 		$sep = $params->get( 1 );
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
-		$csOption = ListUtils::decodeCSOption( $params->get( 2 ) );
-
 		$values = ListUtils::explode( $sep, $inList );
+
+		if ( count( $values ) === 0 ) {
+			return '0';
+		}
+
+		$csOption = ListUtils::decodeCSOption( $params->get( 2 ) );
 		$values = $this->reduceToUniqueValues( $values, $csOption );
+
 		return (string)count( $values );
 	}
 }

--- a/src/Function/List/LstCntUniqFunction.php
+++ b/src/Function/List/LstCntUniqFunction.php
@@ -32,12 +32,7 @@ final class LstCntUniqFunction extends ListUniqueFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '0';
-		}
-
-		$sep = $params->get( 1 );
+		$sep = $inList !== '' ? $params->get( 1 ) : '';
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$values = ListUtils::explode( $sep, $inList );
 

--- a/src/Function/List/LstElemFunction.php
+++ b/src/Function/List/LstElemFunction.php
@@ -34,12 +34,7 @@ final class LstElemFunction implements ParserFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 1 );
+		$inSep = $inList !== '' ? $params->get( 1 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstElemFunction.php
+++ b/src/Function/List/LstElemFunction.php
@@ -41,10 +41,15 @@ final class LstElemFunction implements ParserFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return '';
+		}
+
 		$index = $params->get( 2 );
 		$index = is_numeric( $index ) ? intval( $index ) : 1;
-
-		$value = ListUtils::get( ListUtils::explode( $inSep, $inList ), $index );
+		$value = ListUtils::get( $inValues, $index );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $value );
 	}

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -46,7 +46,6 @@ final class LstFltrFunction extends ListFilterFunction {
 		$valueSep = $params->get( 1 );
 		$inSep = $params->get( 3 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 4 );
 		$csOption = ListUtils::decodeCSOption( $params->get( 5 ) );
 
 		$inValues = ListUtils::explode( $inSep, $inList );
@@ -60,10 +59,9 @@ final class LstFltrFunction extends ListFilterFunction {
 		$operation = new ListInclusionOperation( $values, '', 'remove', $csOption );
 		$outValues = $this->filterList( $operation, $inValues );
 
-		if ( count( $outValues ) > 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $outValues, $outSep ) );
-		} else {
-			return '';
-		}
+		$outSep = count( $outValues ) > 1 ? $params->get( 4 ) : '';
+		$outList = ListUtils::implode( $outValues, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -42,13 +42,17 @@ final class LstFltrFunction extends ListFilterFunction {
 			return '';
 		}
 
-		$values = $params->get( 0 );
-		$valueSep = $params->get( 1 );
 		$inSep = $params->get( 3 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$csOption = ListUtils::decodeCSOption( $params->get( 5 ) );
-
 		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return '';
+		}
+
+		$values = $params->get( 0 );
+		$valueSep = $params->get( 1 );
+		$csOption = ListUtils::decodeCSOption( $params->get( 5 ) );
 
 		if ( $valueSep !== '' ) {
 			$values = ListUtils::explode( $valueSep, $values );

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -37,12 +37,7 @@ final class LstFltrFunction extends ListFilterFunction {
 		] );
 
 		$inList = $params->get( 2 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 3 );
+		$inSep = $inList !== '' ? $params->get( 3 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstFndFunction.php
+++ b/src/Function/List/LstFndFunction.php
@@ -35,12 +35,7 @@ final class LstFndFunction implements ParserFunction {
 		] );
 
 		$list = $params->get( 1 );
-
-		if ( $list === '' ) {
-			return '';
-		}
-
-		$sep = $params->get( 2 );
+		$sep = $list !== '' ? $params->get( 2 ) : '';
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$values = ListUtils::explode( $sep, $list );
 

--- a/src/Function/List/LstFndFunction.php
+++ b/src/Function/List/LstFndFunction.php
@@ -40,13 +40,18 @@ final class LstFndFunction implements ParserFunction {
 			return '';
 		}
 
-		$item = $params->get( 0 );
 		$sep = $params->get( 2 );
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
+		$values = ListUtils::explode( $sep, $list );
+
+		if ( count( $values ) === 0 ) {
+			return '';
+		}
+
+		$item = $params->get( 0 );
+
 		$csOption = $params->get( 3 );
 		$csOption = ListUtils::decodeCSOption( $csOption );
-
-		$values = ListUtils::explode( $sep, $list );
 		if ( $csOption ) {
 			foreach ( $values as $value ) {
 				if ( $value === $item ) {

--- a/src/Function/List/LstIndFunction.php
+++ b/src/Function/List/LstIndFunction.php
@@ -39,13 +39,18 @@ final class LstIndFunction implements ParserFunction {
 			return '';
 		}
 
-		$item = $params->get( 0 );
 		$sep = $params->get( 2 );
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
-		$options = ListUtils::decodeIndexOptions( $params->get( 3 ) );
-
 		$values = ListUtils::explode( $sep, $list );
-		$count = ( is_array( $values ) || $values instanceof Countable ) ? count( $values ) : 0;
+
+		$count = count( $values );
+		if ( $count === 0 ) {
+			return '';
+		}
+
+		$item = $params->get( 0 );
+
+		$options = ListUtils::decodeIndexOptions( $params->get( 3 ) );
 		if ( $options & ListUtils::INDEX_DESC ) {
 			if ( $options & ListUtils::INDEX_CS ) {
 				for ( $index = $count - 1; $index > -1; --$index ) {

--- a/src/Function/List/LstIndFunction.php
+++ b/src/Function/List/LstIndFunction.php
@@ -34,12 +34,7 @@ final class LstIndFunction implements ParserFunction {
 		] );
 
 		$list = $params->get( 1 );
-
-		if ( $list === '' ) {
-			return '';
-		}
-
-		$sep = $params->get( 2 );
+		$sep = $list !== '' ? $params->get( 2 ) : '';
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$values = ListUtils::explode( $sep, $list );
 

--- a/src/Function/List/LstJoinFunction.php
+++ b/src/Function/List/LstJoinFunction.php
@@ -57,9 +57,11 @@ final class LstJoinFunction implements ParserFunction {
 			$values2 = ListUtils::explode( $inSep2, $inList2 );
 		}
 
-		$outSep = $params->get( 4 );
-
 		$values = array_merge( $values1, $values2 );
-		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $outSep ) );
+
+		$outSep = count( $values ) > 1 ? $params->get( 4 ) : '';
+		$outList = ListUtils::implode( $values, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstJoinFunction.php
+++ b/src/Function/List/LstJoinFunction.php
@@ -36,26 +36,14 @@ final class LstJoinFunction implements ParserFunction {
 		] );
 
 		$inList1 = $params->get( 0 );
+		$inSep1 = $inList1 !== '' ? $params->get( 1 ) : '';
+		$inSep1 = $parser->getStripState()->unstripNoWiki( $inSep1 );
+		$values1 = ListUtils::explode( $inSep1, $inList1 );
+
 		$inList2 = $params->get( 2 );
-		if ( $inList1 === '' && $inList2 === '' ) {
-			return '';
-		}
-
-		if ( $inList1 === '' ) {
-			$values1 = [];
-		} else {
-			$inSep1 = $params->get( 1 );
-			$inSep1 = $parser->getStripState()->unstripNoWiki( $inSep1 );
-			$values1 = ListUtils::explode( $inSep1, $inList1 );
-		}
-
-		if ( $inList2 === '' ) {
-			$values2 = [];
-		} else {
-			$inSep2 = $params->get( 3 );
-			$inSep2 = $parser->getStripState()->unstripNoWiki( $inSep2 );
-			$values2 = ListUtils::explode( $inSep2, $inList2 );
-		}
+		$inSep2 = $inList2 !== '' ? $params->get( 3 ) : '';
+		$inSep2 = $parser->getStripState()->unstripNoWiki( $inSep2 );
+		$values2 = ListUtils::explode( $inSep2, $inList2 );
 
 		$values = array_merge( $values1, $values2 );
 

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -68,9 +68,9 @@ final class LstMapFunction extends ListMapFunction {
 
 		$token = $params->get( 2 );
 		$pattern = $params->get( 3 );
-		$sortMode = ListUtils::decodeSortMode( $params->get( 5 ) );
-		$sortOptions = ListUtils::decodeSortOptions( $params->get( 6 ) );
 
+		$sortMode = ListUtils::decodeSortMode( $params->get( 5 ) );
+		$sortOptions = $sortMode > 0 ? ListUtils::decodeSortOptions( $params->get( 6 ) ) : 0;
 		$sorter = new ListSorter( $sortOptions );
 
 		if ( $sortMode & ListUtils::SORTMODE_PRE ) {

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -53,12 +53,7 @@ final class LstMapFunction extends ListMapFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 1 );
+		$inSep = $inList !== '' ? $params->get( 1 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -62,7 +62,6 @@ final class LstMapFunction extends ListMapFunction {
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$token = $params->get( 2 );
 		$pattern = $params->get( 3 );
-		$outSep = $params->get( 4 );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 5 ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 6 ) );
 
@@ -81,10 +80,9 @@ final class LstMapFunction extends ListMapFunction {
 			$outValues = $sorter->sort( $outValues );
 		}
 
-		if ( count( $outValues ) === 0 ) {
-			return '';
-		}
+		$outSep = count( $outValues ) > 1 ? $params->get( 4 ) : '';
+		$outList = ListUtils::implode( $outValues, $outSep );
 
-		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $outValues, $outSep ) );
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -60,14 +60,18 @@ final class LstMapFunction extends ListMapFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return '';
+		}
+
 		$token = $params->get( 2 );
 		$pattern = $params->get( 3 );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 5 ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 6 ) );
 
 		$sorter = new ListSorter( $sortOptions );
-
-		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( $sortMode & ListUtils::SORTMODE_PRE ) {
 			$inValues = $sorter->sort( $inValues );

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -52,9 +52,9 @@ final class LstMapTempFunction extends ListMapFunction {
 		}
 
 		$template = $params->get( 1 );
-		$sortMode = ListUtils::decodeSortMode( $params->get( 4 ) );
-		$sortOptions = ListUtils::decodeSortOptions( $params->get( 5 ) );
 
+		$sortMode = ListUtils::decodeSortMode( $params->get( 4 ) );
+		$sortOptions = $sortMode > 0 ? ListUtils::decodeSortOptions( $params->get( 5 ) ) : 0;
 		$sorter = new ListSorter( $sortOptions );
 
 		if ( $sortMode & ListUtils::SORTMODE_PRE ) {

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -38,12 +38,7 @@ final class LstMapTempFunction extends ListMapFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 2 );
+		$inSep = $inList !== '' ? $params->get( 2 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -46,7 +46,6 @@ final class LstMapTempFunction extends ListMapFunction {
 		$template = $params->get( 1 );
 		$inSep = $params->get( 2 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 3 );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 4 ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 5 ) );
 
@@ -65,10 +64,9 @@ final class LstMapTempFunction extends ListMapFunction {
 			$outValues = $sorter->sort( $outValues );
 		}
 
-		if ( count( $outValues ) === 0 ) {
-			return '';
-		}
+		$outSep = count( $outValues ) > 1 ? $params->get( 3 ) : '';
+		$outList = ListUtils::implode( $outValues, $outSep );
 
-		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $outValues, $outSep ) );
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -43,15 +43,19 @@ final class LstMapTempFunction extends ListMapFunction {
 			return '';
 		}
 
-		$template = $params->get( 1 );
 		$inSep = $params->get( 2 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return '';
+		}
+
+		$template = $params->get( 1 );
 		$sortMode = ListUtils::decodeSortMode( $params->get( 4 ) );
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 5 ) );
 
 		$sorter = new ListSorter( $sortOptions );
-
-		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( $sortMode & ListUtils::SORTMODE_PRE ) {
 			$inValues = $sorter->sort( $inValues );

--- a/src/Function/List/LstPrepFunction.php
+++ b/src/Function/List/LstPrepFunction.php
@@ -42,11 +42,12 @@ final class LstPrepFunction implements ParserFunction {
 
 		$sep = $params->get( 1 );
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
-
 		$values = ListUtils::explode( $sep, $list );
+
 		if ( $value !== '' ) {
 			array_unshift( $values, $value );
 		}
+
 		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $sep ) );
 	}
 }

--- a/src/Function/List/LstPrepFunction.php
+++ b/src/Function/List/LstPrepFunction.php
@@ -35,12 +35,7 @@ final class LstPrepFunction implements ParserFunction {
 
 		$value = $params->get( 0 );
 		$list = $params->get( 2 );
-
-		if ( $list === '' ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, $value );
-		}
-
-		$sep = $params->get( 1 );
+		$sep = $list !== '' ? $params->get( 1 ) : '';
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$values = ListUtils::explode( $sep, $list );
 

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -44,7 +44,6 @@ final class LstRmFunction extends ListFilterFunction {
 		$value = $params->get( 0 );
 		$inSep = $params->get( 2 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 3 );
 		$csOption = ListUtils::decodeCSOption( $params->get( 4 ) );
 
 		$inValues = ListUtils::explode( $inSep, $inList );
@@ -52,10 +51,9 @@ final class LstRmFunction extends ListFilterFunction {
 		$operation = new ListInclusionOperation( [ $value ], 'remove', '', $csOption );
 		$outValues = $this->filterList( $operation, $inValues );
 
-		if ( count( $outValues ) > 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $outValues, $outSep ) );
-		} else {
-			return '';
-		}
+		$outSep = count( $outValues ) > 1 ? $params->get( 3 ) : '';
+		$outList = ListUtils::implode( $outValues, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -41,13 +41,16 @@ final class LstRmFunction extends ListFilterFunction {
 			return '';
 		}
 
-		$value = $params->get( 0 );
 		$inSep = $params->get( 2 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$csOption = ListUtils::decodeCSOption( $params->get( 4 ) );
-
 		$inValues = ListUtils::explode( $inSep, $inList );
 
+		if ( count( $inValues ) === 0 ) {
+			return '';
+		}
+
+		$value = $params->get( 0 );
+		$csOption = ListUtils::decodeCSOption( $params->get( 4 ) );
 		$operation = new ListInclusionOperation( [ $value ], 'remove', '', $csOption );
 		$outValues = $this->filterList( $operation, $inValues );
 

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -36,12 +36,7 @@ final class LstRmFunction extends ListFilterFunction {
 		] );
 
 		$inList = $params->get( 1 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 2 );
+		$inSep = $inList !== '' ? $params->get( 2 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstSepFunction.php
+++ b/src/Function/List/LstSepFunction.php
@@ -34,11 +34,7 @@ final class LstSepFunction implements ParserFunction {
 		] );
 
 		$inList = $params->get( 0 );
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 1 );
+		$inSep = $inList !== '' ? $params->get( 1 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$values = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstSepFunction.php
+++ b/src/Function/List/LstSepFunction.php
@@ -40,9 +40,11 @@ final class LstSepFunction implements ParserFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 2 );
-
 		$values = ListUtils::explode( $inSep, $inList );
-		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $outSep ) );
+
+		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';
+		$outList = ListUtils::implode( $values, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -42,13 +42,16 @@ final class LstSrtFunction extends ListSortFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 2 );
 
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 3 ) );
 		$sorter = new ListSorter( $sortOptions );
 
 		$values = ListUtils::explode( $inSep, $inList );
 		$values = $sorter->sort( $values );
-		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $outSep ) );
+
+		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';
+		$outList = ListUtils::implode( $values, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -42,11 +42,14 @@ final class LstSrtFunction extends ListSortFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$values = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $values ) === 0 ) {
+			return '';
+		}
 
 		$sortOptions = ListUtils::decodeSortOptions( $params->get( 3 ) );
 		$sorter = new ListSorter( $sortOptions );
-
-		$values = ListUtils::explode( $inSep, $inList );
 		$values = $sorter->sort( $values );
 
 		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -35,12 +35,7 @@ final class LstSrtFunction extends ListSortFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 1 );
+		$inSep = $inList !== '' ? $params->get( 1 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$values = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstSubFunction.php
+++ b/src/Function/List/LstSubFunction.php
@@ -36,12 +36,7 @@ final class LstSubFunction implements ParserFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 1 );
+		$inSep = $inList !== '' ? $params->get( 1 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstSubFunction.php
+++ b/src/Function/List/LstSubFunction.php
@@ -43,7 +43,6 @@ final class LstSubFunction implements ParserFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 2 );
 		$offset = $params->get( 3 );
 		$offset = is_numeric( $offset ) ? intval( $offset ) : 0;
 		$length = $params->get( 4 );
@@ -51,10 +50,9 @@ final class LstSubFunction implements ParserFunction {
 
 		$values = ListUtils::slice( ListUtils::explode( $inSep, $inList ), $offset, $length );
 
-		if ( count( $values ) > 0 ) {
-			return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $outSep ) );
-		} else {
-			return '';
-		}
+		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';
+		$outList = ListUtils::implode( $values, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }

--- a/src/Function/List/LstSubFunction.php
+++ b/src/Function/List/LstSubFunction.php
@@ -45,13 +45,14 @@ final class LstSubFunction implements ParserFunction {
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 
-		if ( count( $inValues ) === 0 ) {
+		$inCount = count( $inValues );
+		if ( $inCount === 0 ) {
 			return '';
 		}
 
 		$offset = $params->get( 3 );
 		$offset = is_numeric( $offset ) ? intval( $offset ) : 0;
-		$length = $params->get( 4 );
+		$length = $offset < $inCount ? $params->get( 4 ) : '';
 		$length = is_numeric( $length ) ? intval( $length ) : null;
 		$outValues = ListUtils::slice( $inValues, $offset, $length );
 

--- a/src/Function/List/LstSubFunction.php
+++ b/src/Function/List/LstSubFunction.php
@@ -43,15 +43,20 @@ final class LstSubFunction implements ParserFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$inValues = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $inValues ) === 0 ) {
+			return '';
+		}
+
 		$offset = $params->get( 3 );
 		$offset = is_numeric( $offset ) ? intval( $offset ) : 0;
 		$length = $params->get( 4 );
 		$length = is_numeric( $length ) ? intval( $length ) : null;
+		$outValues = ListUtils::slice( $inValues, $offset, $length );
 
-		$values = ListUtils::slice( ListUtils::explode( $inSep, $inList ), $offset, $length );
-
-		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';
-		$outList = ListUtils::implode( $values, $outSep );
+		$outSep = count( $outValues ) > 1 ? $params->get( 2 ) : '';
+		$outList = ListUtils::implode( $outValues, $outSep );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -34,12 +34,7 @@ final class LstUniqFunction extends ListUniqueFunction {
 		] );
 
 		$inList = $params->get( 0 );
-
-		if ( $inList === '' ) {
-			return '';
-		}
-
-		$inSep = $params->get( 1 );
+		$inSep = $inList !== '' ? $params->get( 1 ) : '';
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$values = ListUtils::explode( $inSep, $inList );
 

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -41,9 +41,13 @@ final class LstUniqFunction extends ListUniqueFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$csOption = ListUtils::decodeCSOption( $params->get( 3 ) );
-
 		$values = ListUtils::explode( $inSep, $inList );
+
+		if ( count( $values ) === 0 ) {
+			return '';
+		}
+
+		$csOption = ListUtils::decodeCSOption( $params->get( 3 ) );
 		$values = $this->reduceToUniqueValues( $values, $csOption );
 
 		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -41,11 +41,14 @@ final class LstUniqFunction extends ListUniqueFunction {
 
 		$inSep = $params->get( 1 );
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$outSep = $params->get( 2 );
 		$csOption = ListUtils::decodeCSOption( $params->get( 3 ) );
 
 		$values = ListUtils::explode( $inSep, $inList );
 		$values = $this->reduceToUniqueValues( $values, $csOption );
-		return ParserPower::evaluateUnescaped( $parser, $frame, ListUtils::implode( $values, $outSep ) );
+
+		$outSep = count( $values ) > 1 ? $params->get( 2 ) : '';
+		$outList = ListUtils::implode( $values, $outSep );
+
+		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }


### PR DESCRIPTION
## Context

Issue #3 is about making parser functions evaluate their parameters lazily, only when necessary.

Previous proposals covered additional laziness of non-list related functions:

- #13 for `#tokenif`, and
- #18 for `#ueswitch`.

This PR intends to cover all list functions, to make these evaluate their parameters more lazily.

Note: In this PR the word "evaluation" references all pre-processing steps that are applied to a parameter. This includes expanding variables within a frame and trimming spaces.

## Current state

For manipulating lists, *ParserPower* provides parser functions accepting either indexed parameters (at most 6) or named parameters (at most 19). 

Functions with indexed parameters currently use one laziness rule:

- If the input list(s) is/are empty, do not evaluate other parameters.

Functions with named parameters currently do not use any laziness rule (all parameters are evaluated directly).

From looking at the original code, it seems the rule mentioned above was expected to be used, but in practice never worked, as all parameters were all evaluated beforehand in the `ParserPower::arrangeParams` function. This is no longer an issue, as it has been refactored in 2 previous PRs:

- Since #14 `arrangeParams` evaluates keys, then evaluates values if keys are valid.
- Since #9 `arrangeParams` is no longer responsible for evaluating values.

## Potential breakage

This PR, like other laziness proposals, can break any use case where side effects (e.g. `#vardefine`, `#cargo_store`) are done within a parser function parameter. Most notably:

- Side-effects will no longer be applied if the parameter is not evaluated.
- Evaluation order of parameters may change. For example, the following will no longer work as expected:

```html
{{#listmap:
 | list   = a; b; c
 | outsep = {{#vardefineecho: sep | ; }}
 | insep  = {{#var: sep }}
}}
```

## <span id="changes">Proposed changes</span>

Below is a list of all laziness rules that this PR tries to enforce in list parser functions.

All functions:

- If the input list(s) is/are empty, do not evaluate other parameters.
- If the input list(s) has no non-empty value after being split, do not evaluate other parameters.
- If the output list has less than 2 values, do not evaluate the output separator.
- Only evaluate the default value if it is returned.

All functions with named parameters (`#listunique`/`#listfilter`/`#listsort`/`#listmap`/`#listmerge`):

- If the output list is empty, do not evaluate `intro`/`outro`/`counttoken`.
- If a template is used, do not evaluate pattern-related parameters (`token`/`tokensep`/`indextoken`/`pattern`).
- If no `fieldsep` is used, do not evaluate `tokensep`.

`#lstsub`:

- If the offset parameter is higher than the list size, do not evaluate the length parameter.

`#listfilter`:

- If a template or pattern is used, do not evaluate inclusion-related parameters (`keep`/`keepsep`/`keepcs`).
- If a template, pattern, or inclusion list is used, do not evaluate exclusion-related parameters (`remove`/`removesep`/`removecs`).

`#listsort`:

- If `subsort` is not used, do not evaluate `subsortoptions`.

`#listmap`/`#lstmap`/`#lstmaptemp`:

- If no `sortmode` is used, do not evaluate `sortoptions`.

`#listmerge`:

- If no `sortmode` is used, do not evaluate `sortoptions`.