### PR TITLE
refactor: Merge sort flags, `ListFunctions::sortList`, and `SortKeyValueComparer` into `ListSorter`

### DIFF
--- a/src/ComparisonUtils.php
+++ b/src/ComparisonUtils.php
@@ -7,7 +7,7 @@ namespace MediaWiki\Extension\ParserPower;
 final class ComparisonUtils {
 	/**
 	 * The function compares two strings by numerical value, attempting to match the observed behavior of the built-in
-	 * sort function using SORT_NUMERIC.
+	 * sort function using ListSorter::NUMERIC.
 	 *
 	 * @param string $string1 A string to compare to $string2.
 	 * @param string $string2 A string to compare to $string1.
@@ -19,7 +19,7 @@ final class ComparisonUtils {
 
 	/**
 	 * The function compares two strings by numerical value, attempting to match the observed behavior of the built-in
-	 * sort function using SORT_NUMERIC, except that it gives negated results.
+	 * sort function using ListSorter::NUMERIC, except that it gives negated results.
 	 *
 	 * @param string $string1 A string to compare to $string2.
 	 * @param string $string2 A string to compare to $string1.

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1519,9 +1519,8 @@ final class ListFunctions {
 			);
 		}
 
-		$comparer = new SortKeyValueComparer( $sortOptions, $subsortOptions );
-
-		usort( $pairedValues, [ $comparer, 'compare' ] );
+		$sorter = new ListSorter( $sortOptions, $subsortOptions );
+		$sorter->sortPairs( $pairedValues );
 
 		return self::discardSortKeys( $pairedValues );
 	}

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1488,8 +1488,7 @@ final class ListFunctions {
 	 * @param array|null $tokens Or if there are mulitple fields, the tokens representing where they go.
 	 * @param string $pattern The pattern containing token that list values are inserted into at that token.
 	 * @param int $sortOptions Options for the key sort as handled by #listsort.
-	 * @param bool $subsort Whether to perform a value sort where sort keys are equal.
-	 * @param int $subsortOptions Options for the value sort as handled by #listsort.
+	 * @param ?int $subsortOptions Options for the value sort, null to not sort values.
 	 * @return array An array where each value has been paired with a sort key in a two-element array.
 	 */
 	private static function sortListByKeys(
@@ -1503,7 +1502,6 @@ final class ListFunctions {
 		$tokens,
 		$pattern,
 		$sortOptions,
-		$subsort,
 		$subsortOptions
 	) {
 		if ( $template !== '' ) {
@@ -1521,7 +1519,7 @@ final class ListFunctions {
 			);
 		}
 
-		$comparer = new SortKeyValueComparer( $sortOptions, $subsort, $subsortOptions );
+		$comparer = new SortKeyValueComparer( $sortOptions, $subsortOptions );
 
 		usort( $pairedValues, [ $comparer, 'compare' ] );
 
@@ -1563,8 +1561,14 @@ final class ListFunctions {
 		}
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+
 		$subsort = self::decodeBool( $subsort );
-		$subsortOptions = self::decodeSortOptions( $subsortOptions );
+		if ( $subsort ) {
+			$subsortOptions = self::decodeSortOptions( $subsortOptions );
+		} else {
+			$subsortOptions = null;
+		}
+
 		$duplicates = self::decodeDuplicates( $duplicates );
 
 		$values = self::arrayTrimUnescape( self::explodeList( $inSep, $inList ) );
@@ -1589,7 +1593,6 @@ final class ListFunctions {
 				$tokens ?? null,
 				$pattern,
 				$sortOptions,
-				$subsort,
 				$subsortOptions
 			);
 		} else {

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1330,33 +1330,8 @@ final class ListFunctions {
 	 * @return array The values in an array of strings.
 	 */
 	private static function sortList( array $values, $options ) {
-		if ( $options & self::SORT_NUMERIC ) {
-			if ( $options & self::SORT_DESC ) {
-				rsort( $values, SORT_NUMERIC );
-				return $values;
-			} else {
-				sort( $values, SORT_NUMERIC );
-				return $values;
-			}
-		} else {
-			if ( $options & self::SORT_CS ) {
-				if ( $options & self::SORT_DESC ) {
-					rsort( $values, SORT_STRING );
-					return $values;
-				} else {
-					sort( $values, SORT_STRING );
-					return $values;
-				}
-			} else {
-				if ( $options & self::SORT_DESC ) {
-					usort( $values, [ ComparisonUtils::class, 'rstrcasecmp' ] );
-					return $values;
-				} else {
-					usort( $values, 'strcasecmp' );
-					return $values;
-				}
-			}
-		}
+		$sorter = new ListSorter( $options );
+		return $sorter->sort( $values );
 	}
 
 	/**

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1323,18 +1323,6 @@ final class ListFunctions {
 	}
 
 	/**
-	 * This function sorts an array according to the parameters supplied.
-	 *
-	 * @param array $values An array of values to sort.
-	 * @param int $options The sorting options parameter value as provided by the user.
-	 * @return array The values in an array of strings.
-	 */
-	private static function sortList( array $values, $options ) {
-		$sorter = new ListSorter( $options );
-		return $sorter->sort( $values );
-	}
-
-	/**
 	 * Generates the sort keys by replacing tokens in a pattern with the fields in the values. This returns an array
 	 * of the values where each element is an array with the sort key in element 0 and the value in element 1.
 	 *
@@ -1571,7 +1559,8 @@ final class ListFunctions {
 			);
 		} else {
 			$sortOptions = self::decodeSortOptions( $sortOptions );
-			$values = self::sortList( $values, $sortOptions );
+			$sorter = new ListSorter( $sortOptions );
+			$values = $sorter->sort( $values );
 		}
 
 		if ( count( $values ) === 0 ) {
@@ -1604,9 +1593,10 @@ final class ListFunctions {
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$sortOptions = self::decodeSortOptions( $sortOptions );
+		$sorter = new ListSorter( $sortOptions );
 
 		$values = self::arrayTrimUnescape( self::explodeList( $inSep, $inList ) );
-		$values = self::sortList( $values, $sortOptions );
+		$values = $sorter->sort( $values );
 		return ParserPower::evaluateUnescaped( $parser, $frame, implode( $outSep, $values ) );
 	}
 
@@ -1657,6 +1647,8 @@ final class ListFunctions {
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
+		$sorter = new ListSorter( $sortOptions );
+
 		$inValues = self::arrayTrimUnescape( self::explodeList( $inSep, $inList ) );
 
 		if ( $duplicates & self::DUPLICATES_PRESTRIP ) {
@@ -1664,7 +1656,7 @@ final class ListFunctions {
 		}
 
 		if ( ( $indexToken !== '' && $sortMode & self::SORTMODE_COMPAT ) || $sortMode & self::SORTMODE_PRE ) {
-			$inValues = self::sortList( $inValues, $sortOptions );
+			$inValues = $sorter->sort( $inValues );
 		}
 
 		$outValues = [];
@@ -1708,7 +1700,7 @@ final class ListFunctions {
 		}
 
 		if ( ( $indexToken === '' && $sortMode & self::SORTMODE_COMPAT ) || $sortMode & self::SORTMODE_POST ) {
-			$outValues = self::sortList( $outValues, $sortOptions );
+			$outValues = $sorter->sort( $outValues );
 		}
 
 		if ( count( $outValues ) === 0 ) {
@@ -1763,13 +1755,15 @@ final class ListFunctions {
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
+		$sorter = new ListSorter( $sortOptions );
+
 		$inValues = self::arrayTrimUnescape( self::explodeList( $inSep, $inList ) );
 		if ( $duplicates & self::DUPLICATES_PRESTRIP ) {
 			$inValues = array_unique( $inValues );
 		}
 
 		if ( $sortMode & self::SORTMODE_PRE ) {
-			$inValues = self::sortList( $inValues, $sortOptions );
+			$inValues = $sorter->sort( $inValues );
 		}
 
 		$outValues = [];
@@ -1778,7 +1772,7 @@ final class ListFunctions {
 		}
 
 		if ( $sortMode & ( self::SORTMODE_POST | self::SORTMODE_COMPAT ) ) {
-			$outValues = self::sortList( $outValues, $sortOptions );
+			$outValues = $sorter->sort( $outValues );
 		}
 
 		if ( $duplicates & self::DUPLICATES_POSTSTRIP ) {
@@ -2183,10 +2177,12 @@ final class ListFunctions {
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
+		$sorter = new ListSorter( $sortOptions );
+
 		$inValues = self::arrayTrimUnescape( self::explodeList( $inSep, $inList ) );
 
 		if ( $sortMode & self::SORTMODE_PRE ) {
-			$inValues = self::sortList( $inValues, $sortOptions );
+			$inValues = $sorter->sort( $inValues );
 		}
 
 		if ( $tokenSep !== '' ) {
@@ -2211,7 +2207,7 @@ final class ListFunctions {
 		);
 
 		if ( $sortMode & ( self::SORTMODE_POST | self::SORTMODE_COMPAT ) ) {
-			$outValues = self::sortList( $outValues, $sortOptions );
+			$outValues = $sorter->sort( $outValues );
 		}
 
 		if ( count( $outValues ) === 0 ) {
@@ -2264,10 +2260,12 @@ final class ListFunctions {
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
+		$sorter = new ListSorter( $sortOptions );
+
 		$inValues = self::arrayTrimUnescape( self::explodeList( $inSep, $inList ) );
 
 		if ( $sortMode & self::SORTMODE_PRE ) {
-			$inValues = self::sortList( $inValues, $sortOptions );
+			$inValues = $sorter->sort( $inValues );
 		}
 
 		$matchParams = [ $parser, $frame, null, null, $matchTemplate, $fieldSep ];
@@ -2284,7 +2282,7 @@ final class ListFunctions {
 		);
 
 		if ( $sortMode & ( self::SORTMODE_POST | self::SORTMODE_COMPAT ) ) {
-			$outValues = self::sortList( $outValues, $sortOptions );
+			$outValues = $sorter->sort( $outValues );
 		}
 
 		if ( count( $outValues ) === 0 ) {

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -11,31 +11,6 @@ use MediaWiki\Parser\PPNode_Hash_Array;
 
 final class ListFunctions {
 	/**
-	 * Flag for alphanumeric sorting. 0 as this is a default mode.
-	 */
-	public const SORT_ALPHA = 0;
-	/**
-	 * Flag for numeric sorting.
-	 */
-	public const SORT_NUMERIC = 4;
-	/**
-	 * Flag for case insensitive sorting. 0 as this is a default mode, and ignored in numeric sorts.
-	 */
-	public const SORT_NCS = 0;
-	/**
-	 * Flag for case sensitive sorting. 0 as this is a default mode, and ignored in numeric sorts.
-	 */
-	public const SORT_CS = 2;
-	/**
-	 * Flag for sorting in ascending order. 0 as this is a default mode.
-	 */
-	public const SORT_ASC = 0;
-	/**
-	 * Flag for sorting in descending order.
-	 */
-	public const SORT_DESC = 1;
-
-	/**
 	 * Flag for index search returning a positive index. 0 as this is a default mode.
 	 */
 	public const INDEX_POS = 0;
@@ -177,22 +152,22 @@ final class ListFunctions {
 		foreach ( $optionKeywords as $optionKeyword ) {
 			switch ( strtolower( trim( $optionKeyword ) ) ) {
 				case 'numeric':
-					$options |= self::SORT_NUMERIC;
+					$options |= ListSorter::NUMERIC;
 					break;
 				case 'alpha':
-					$options &= ~self::SORT_NUMERIC;
+					$options &= ~ListSorter::NUMERIC;
 					break;
 				case 'cs':
-					$options |= self::SORT_CS;
+					$options |= ListSorter::CASE_SENSITIVE;
 					break;
 				case 'ncs':
-					$options &= ~self::SORT_CS;
+					$options &= ~ListSorter::CASE_SENSITIVE;
 					break;
 				case 'desc':
-					$options |= self::SORT_DESC;
+					$options |= ListSorter::DESCENDING;
 					break;
 				case 'asc':
-					$options &= ~self::SORT_DESC;
+					$options &= ~ListSorter::DESCENDING;
 					break;
 			}
 		}
@@ -1543,7 +1518,7 @@ final class ListFunctions {
 		}
 
 		if ( $template !== '' || ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) ) {
-			$sortOptions = self::decodeSortOptions( $sortOptions, self::SORT_NUMERIC );
+			$sortOptions = self::decodeSortOptions( $sortOptions, ListSorter::NUMERIC );
 			$values = self::sortListByKeys(
 				$parser,
 				$frame,

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -1418,6 +1418,7 @@ final class ListFunctions {
 	 *
 	 * @param Parser $parser The parser object.
 	 * @param PPFrame $frame The parser frame object.
+	 * @param ListSorter $sorter The list sorter.
 	 * @param array $values The input list.
 	 * @param string $template The template to use.
 	 * @param string $fieldSep The delimiter separating values in the input list.
@@ -1425,22 +1426,19 @@ final class ListFunctions {
 	 * @param string $token The token in the pattern that represents where the list value should go.
 	 * @param array|null $tokens Or if there are mulitple fields, the tokens representing where they go.
 	 * @param string $pattern The pattern containing token that list values are inserted into at that token.
-	 * @param int $sortOptions Options for the key sort as handled by #listsort.
-	 * @param ?int $subsortOptions Options for the value sort, null to not sort values.
 	 * @return array An array where each value has been paired with a sort key in a two-element array.
 	 */
 	private static function sortListByKeys(
 		Parser $parser,
 		PPFrame $frame,
+		ListSorter $sorter,
 		array $values,
 		$template,
 		$fieldSep,
 		$indexToken,
 		$token,
 		$tokens,
-		$pattern,
-		$sortOptions,
-		$subsortOptions
+		$pattern
 	) {
 		if ( $template !== '' ) {
 			$pairedValues = self::generateSortKeysByTemplate( $parser, $frame, $values, $template, $fieldSep );
@@ -1457,7 +1455,6 @@ final class ListFunctions {
 			);
 		}
 
-		$sorter = new ListSorter( $sortOptions, $subsortOptions );
 		$sorter->sortPairs( $pairedValues );
 
 		return self::discardSortKeys( $pairedValues );
@@ -1519,18 +1516,18 @@ final class ListFunctions {
 
 		if ( $template !== '' || ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) ) {
 			$sortOptions = self::decodeSortOptions( $sortOptions, ListSorter::NUMERIC );
+			$sorter = new ListSorter( $sortOptions, $subsortOptions );
 			$values = self::sortListByKeys(
 				$parser,
 				$frame,
+				$sorter,
 				$values,
 				$template,
 				$fieldSep,
 				$indexToken,
 				$token,
 				$tokens ?? null,
-				$pattern,
-				$sortOptions,
-				$subsortOptions
+				$pattern
 			);
 		} else {
 			$sortOptions = self::decodeSortOptions( $sortOptions );

--- a/src/ListSorter.php
+++ b/src/ListSorter.php
@@ -5,6 +5,18 @@
 namespace MediaWiki\Extension\ParserPower;
 
 class ListSorter {
+	/**
+	 * Flag for numeric sorting, instead of alphanumeric.
+	 */
+	public const NUMERIC = 4;
+	/**
+	 * Flag for case sensitive sorting. 0 as this is a default mode, and ignored in numeric sorts.
+	 */
+	public const CASE_SENSITIVE = 2;
+	/**
+	 * Flag for sorting in descending order.
+	 */
+	public const DESCENDING = 1;
 
 	/**
 	 * Function to use to compare values.
@@ -77,21 +89,21 @@ class ListSorter {
 	 * @return callable
 	 */
 	private function getComparer( int $options ): callable {
-		if ( $options & ListFunctions::SORT_NUMERIC ) {
-			if ( $options & ListFunctions::SORT_DESC ) {
+		if ( $options & self::NUMERIC ) {
+			if ( $options & self::DESCENDING ) {
 				return [ ComparisonUtils::class, 'numericrstrcmp' ];
 			} else {
 				return [ ComparisonUtils::class, 'numericstrcmp' ];
 			}
 		} else {
-			if ( $options & ListFunctions::SORT_CS ) {
-				if ( $options & ListFunctions::SORT_DESC ) {
+			if ( $options & self::CASE_SENSITIVE ) {
+				if ( $options & self::DESCENDING ) {
 					return [ ComparisonUtils::class, 'rstrcmp' ];
 				} else {
 					return 'strcmp';
 				}
 			} else {
-				if ( $options & ListFunctions::SORT_DESC ) {
+				if ( $options & self::DESCENDING ) {
 					return [ ComparisonUtils::class, 'rstrcasecmp' ];
 				} else {
 					return 'strcasecmp';

--- a/src/ListSorter.php
+++ b/src/ListSorter.php
@@ -4,7 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower;
 
-class SortKeyValueComparer {
+class ListSorter {
 
 	/**
 	 * Function to use to compare values.
@@ -32,13 +32,24 @@ class SortKeyValueComparer {
 	}
 
 	/**
+	 * Sorts a list of pairs of values.
+	 *
+	 * @param array $pairs Value pairs to sort.
+	 * @return array The sorted list of value pairs.
+	 */
+	public function sortPairs( array &$pairs ): array {
+		usort( $pairs, [ $this, 'comparePairs' ] );
+		return $pairs;
+	}
+
+	/**
 	 * Compares two pairs of values, with the first one given priority.
 	 *
 	 * @param array $pair1 Value pair to compare to $pair2.
 	 * @param array $pair2 Value pair to compare to $pair1.
 	 * @return int Number > 0 if $pair1 is less than $pair2, Number < 0 if $pair1 is greater than $pair2, or 0 if they are equal.
 	 */
-	public function compare( array $pair1, array $pair2 ): int {
+	private function comparePairs( array $pair1, array $pair2 ): int {
 		$result = call_user_func( $this->valueCompare, $pair1[0], $pair2[0] );
 
 		if ( $result !== 0 || $this->subValueCompare === null ) {

--- a/src/ListSorter.php
+++ b/src/ListSorter.php
@@ -37,9 +37,9 @@ class ListSorter {
 	 * @param ?int $subSortOptions Options for the sub-value sort, null to not sort sub-values.
 	 */
 	public function __construct( int $sortOptions, ?int $subSortOptions = null ) {
-		$this->valueCompare = $this->getComparer( $sortOptions );
+		$this->valueCompare = self::getComparer( $sortOptions );
 		if ( $subSortOptions !== null ) {
-			$this->subValueCompare = $this->getComparer( $subSortOptions );
+			$this->subValueCompare = self::getComparer( $subSortOptions );
 		}
 	}
 
@@ -83,12 +83,12 @@ class ListSorter {
 	}
 
 	/**
-	 * Get Comparer class
+	 * Get the comparison function associated to a given set of sort options.
 	 *
-	 * @param int $options
-	 * @return callable
+	 * @param int $options Options for a value or sub-value sort.
+	 * @return callable A comparison function.
 	 */
-	private function getComparer( int $options ): callable {
+	private static function getComparer( int $options ): callable {
 		if ( $options & self::NUMERIC ) {
 			if ( $options & self::DESCENDING ) {
 				return [ ComparisonUtils::class, 'numericrstrcmp' ];

--- a/src/ListSorter.php
+++ b/src/ListSorter.php
@@ -32,6 +32,17 @@ class ListSorter {
 	}
 
 	/**
+	 * Sorts a list of values.
+	 *
+	 * @param array $values Values to sort.
+	 * @return array The sorted list of values.
+	 */
+	public function sort( array &$values ): array {
+		usort( $values, $this->valueCompare );
+		return $values;
+	}
+
+	/**
 	 * Sorts a list of pairs of values.
 	 *
 	 * @param array $pairs Value pairs to sort.

--- a/src/ListSorter.php
+++ b/src/ListSorter.php
@@ -4,7 +4,11 @@
 
 namespace MediaWiki\Extension\ParserPower;
 
-class ListSorter {
+/**
+ * Sorting method for lists of values, optionally paired with sub-values.
+ */
+final class ListSorter {
+
 	/**
 	 * Flag for numeric sorting, instead of alphanumeric.
 	 */
@@ -46,7 +50,7 @@ class ListSorter {
 	/**
 	 * Sorts a list of values.
 	 *
-	 * @param array $values Values to sort.
+	 * @param array &$values Values to sort.
 	 * @return array The sorted list of values.
 	 */
 	public function sort( array &$values ): array {
@@ -57,7 +61,7 @@ class ListSorter {
 	/**
 	 * Sorts a list of pairs of values.
 	 *
-	 * @param array $pairs Value pairs to sort.
+	 * @param array &$pairs Value pairs to sort.
 	 * @return array The sorted list of value pairs.
 	 */
 	public function sortPairs( array &$pairs ): array {

--- a/src/SortKeyValueComparer.php
+++ b/src/SortKeyValueComparer.php
@@ -15,7 +15,7 @@ class SortKeyValueComparer {
 	/**
 	 * The function to use to compare values, if any.
 	 *
-	 * @var callable
+	 * @var ?callable
 	 */
 	private $mValueCompare = null;
 
@@ -23,12 +23,11 @@ class SortKeyValueComparer {
 	 * Constructs a ParserPowerSortKeyComparer from the given options.
 	 *
 	 * @param int $sortKeyOptions The options for the key sort.
-	 * @param bool $valueSort true to perform a value sort for values with the same key.
-	 * @param int $valueOptions The options for the value sort.
+	 * @param ?int $valueOptions The options for the value sort, null to not sort values.
 	 */
-	public function __construct( $sortKeyOptions, $valueSort, $valueOptions = 0 ) {
+	public function __construct( $sortKeyOptions, $valueOptions = null ) {
 		$this->mSortKeyCompare = $this->getComparer( $sortKeyOptions );
-		if ( $valueSort ) {
+		if ( $valueOptions !== null ) {
 			$this->mValueCompare = $this->getComparer( $valueOptions );
 		}
 	}
@@ -45,7 +44,7 @@ class SortKeyValueComparer {
 		$result = call_user_func( $this->mSortKeyCompare, $pair1[0], $pair2[0] );
 
 		if ( $result === 0 ) {
-			if ( $this->mValueCompare ) {
+			if ( $this->mValueCompare !== null ) {
 				return call_user_func( $this->mValueCompare, $pair1[1], $pair2[1] );
 			} else {
 				return 0;


### PR DESCRIPTION
## Context

Somes parser functions allow to sort lists when provided sort options as indexed or named (`sortoptions`) parameters, in which case the `ListFunctions::sortList` function is used to choose the sort order.

The `#listfilter` parser function allows to sort list values using a sort and a sub-sort function. When a sub-sort is enabled (using `subsort`), sub-sort options can be specified (`subsortoptions`), in which case a `usort()` with a custom `SortKeyValueComparer` is used.

Consequently, parsing sort options into sort functions is done in 2 different places:
- `ListFunctions::sortList` when there is no sub-sort and
- `SortKeyValueComparer::getComparer` when there is a sub-sort.

## Proposed changes

Replace `ListFunctions::sortList` and `SortKeyValueComparer` with a `ListSorter` class for sorting a list with sort options, and optionally sub-sort options.