### PR TITLE
refactor: Replace `ParserPower::arrangeParams()` with a `ParameterArranger` object

### DIFF
--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -53,6 +53,40 @@ final class ListFunctions {
 	public const SORTMODE_POST = 2;
 	public const SORTMODE_COMPAT = 4;
 
+	private const PARAM_OPTIONS = [
+		'counttoken' => [ 'unescape' => true ],
+		'default' => [ 'unescape' => true ],
+		'duplicates' => [],
+		'fieldsep' => [ 'unescape' => true ],
+		'keep' => [],
+		'keepcs' => [],
+		'keepsep' => [ 'default' => ',' ],
+		'indextoken' => [ 'unescape' => true ],
+		'insep' => [ 'unescape' => true, 'default' => ',' ],
+		'intro' => [ 'unescape' => true ],
+		'list' => [],
+		'outro' => [ 'unescape' => true ],
+		'outsep' => [ 'unescape' => true, 'default' => ',\_' ],
+		'matchpattern' => [],
+		'matchtemplate' => [],
+		'mergepattern' => [],
+		'mergetemplate' => [],
+		'pattern' => [],
+		'remove' => [],
+		'removecs' => [],
+		'removesep' => [ 'default' => ',' ],
+		'removecs' => [],
+		'sortoptions' => [],
+		'subsort' => [],
+		'subsortoptions' => [],
+		'template' => [],
+		'token' => [ 'unescape' => true ],
+		'token1' => [ 'unescape' => true ],
+		'token2' => [ 'unescape' => true ],
+		'tokensep' => [ 'unescape' => true, 'default' => ',' ],
+		'uniquecs' => [],
+	];
+
 	/**
 	 * This function converts a string containing a boolean keyword into a boolean.
 	 *
@@ -780,28 +814,28 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listfilterRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params );
+		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default', [ 'unescape' => true ] );
+		$default = $params->get( 'default' );
 
 		$keepValues = $params->get( 'keep' );
-		$keepSep = $params->get( 'keepsep', [ 'default' => ',' ] );
+		$keepSep = $params->get( 'keepsep' );
 		$keepCS = $params->get( 'keepcs' );
 		$removeValues = $params->get( 'remove' );
-		$removeSep = $params->get( 'removesep', [ 'default' => ',' ] );
+		$removeSep = $params->get( 'removesep' );
 		$removeCS = $params->get( 'removecs' );
 		$template = $params->get( 'template' );
-		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
-		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
-		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
-		$token = $params->get( 'token', [ 'unescape' => true ] );
-		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$inSep = $params->get( 'insep' );
+		$fieldSep = $params->get( 'fieldsep' );
+		$indexToken = $params->get( 'indextoken' );
+		$token = $params->get( 'token' );
+		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
-		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
-		$intro = $params->get( 'intro', [ 'unescape' => true ] );
-		$outro = $params->get( 'outro', [ 'unescape' => true ] );
+		$outSep = $params->get( 'outsep' );
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1062,23 +1096,23 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listuniqueRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params );
+		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default', [ 'unescape' => true ] );
+		$default = $params->get( 'default' );
 
 		$uniqueCS = $params->get( 'uniquecs' );
 		$template = $params->get( 'template' );
-		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
-		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
-		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
-		$token = $params->get( 'token', [ 'unescape' => true ] );
-		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$inSep = $params->get( 'insep' );
+		$fieldSep = $params->get( 'fieldsep' );
+		$indexToken = $params->get( 'indextoken' );
+		$token = $params->get( 'token' );
+		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
-		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
-		$intro = $params->get( 'intro', [ 'unescape' => true ] );
-		$outro = $params->get( 'outro', [ 'unescape' => true ] );
+		$outSep = $params->get( 'outsep' );
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1312,26 +1346,26 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listsortRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params );
+		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default', [ 'unescape' => true ] );
+		$default = $params->get( 'default' );
 
 		$template = $params->get( 'template' );
-		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
-		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
-		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
-		$token = $params->get( 'token', [ 'unescape' => true ] );
-		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$inSep = $params->get( 'insep' );
+		$fieldSep = $params->get( 'fieldsep' );
+		$indexToken = $params->get( 'indextoken' );
+		$token = $params->get( 'token' );
+		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$outSep = $params->get( 'outsep' );
 		$sortOptions = $params->get( 'sortoptions' );
 		$subsort = $params->get( 'subsort' );
 		$subsortOptions = $params->get( 'subsortoptions' );
 		$duplicates = $params->get( 'duplicates' );
-		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
-		$intro = $params->get( 'intro', [ 'unescape' => true ] );
-		$outro = $params->get( 'outro', [ 'unescape' => true ] );
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1610,25 +1644,25 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listmapRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params );
+		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default', [ 'unescape' => true ] );
+		$default = $params->get( 'default' );
 
 		$template = $params->get( 'template' );
-		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
-		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
-		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
-		$token = $params->get( 'token', [ 'unescape' => true ] );
-		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$inSep = $params->get( 'insep' );
+		$fieldSep = $params->get( 'fieldsep' );
+		$indexToken = $params->get( 'indextoken' );
+		$token = $params->get( 'token' );
+		$tokenSep = $params->get( 'tokensep' );
 		$pattern = $params->get( 'pattern' );
-		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$outSep = $params->get( 'outsep' );
 		$sortMode = $params->get( 'sortmode' );
 		$sortOptions = $params->get( 'sortoptions' );
 		$duplicates = $params->get( 'duplicates' );
-		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
-		$intro = $params->get( 'intro', [ 'unescape' => true ] );
-		$outro = $params->get( 'outro', [ 'unescape' => true ] );
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -2101,26 +2135,26 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listmergeRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params );
+		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
-		$default = $params->get( 'default', [ 'unescape' => true ] );
+		$default = $params->get( 'default' );
 
 		$matchTemplate = $params->get( 'matchtemplate' );
 		$mergeTemplate = $params->get( 'mergetemplate' );
-		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
-		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
-		$token1 = $params->get( 'token1', [ 'unescape' => true ] );
-		$token2 = $params->get( 'token2', [ 'unescape' => true ] );
-		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$inSep = $params->get( 'insep' );
+		$fieldSep = $params->get( 'fieldsep' );
+		$token1 = $params->get( 'token1' );
+		$token2 = $params->get( 'token2' );
+		$tokenSep = $params->get( 'tokensep' );
 		$matchPattern = $params->get( 'matchpattern' );
 		$mergePattern = $params->get( 'mergepattern' );
-		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$outSep = $params->get( 'outsep' );
 		$sortMode = $params->get( 'sortmode' );
 		$sortOptions = $params->get( 'sortoptions' );
-		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
-		$intro = $params->get( 'intro', [ 'unescape' => true ] );
-		$outro = $params->get( 'outro', [ 'unescape' => true ] );
+		$countToken = $params->get( 'counttoken' );
+		$intro = $params->get( 'intro' );
+		$outro = $params->get( 'outro' );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -780,28 +780,28 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listfilterRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParserPower::arrangeParams( $frame, $params );
+		$params = new ParameterArranger( $frame, $params );
 
-		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
-		$default = ParserPower::expand( $frame, $params["default"] ?? '', ParserPower::UNESCAPE );
+		$inList = $params->get( 'list' );
+		$default = $params->get( 'default', [ 'unescape' => true ] );
 
-		$keepValues = ParserPower::expand( $frame, $params["keep"] ?? '' );
-		$keepSep = ParserPower::expand( $frame, $params["keepsep"] ?? ',' );
-		$keepCS = ParserPower::expand( $frame, $params["keepcs"] ?? '' );
-		$removeValues = ParserPower::expand( $frame, $params["remove"] ?? '' );
-		$removeSep = ParserPower::expand( $frame, $params["removesep"] ?? ',' );
-		$removeCS = ParserPower::expand( $frame, $params["removecs"] ?? '' );
-		$template = ParserPower::expand( $frame, $params["template"] ?? '' );
-		$inSep = ParserPower::expand( $frame, $params["insep"] ?? ',', ParserPower::UNESCAPE );
-		$fieldSep = ParserPower::expand( $frame, $params["fieldsep"] ?? '', ParserPower::UNESCAPE );
-		$indexToken = ParserPower::expand( $frame, $params["indextoken"] ?? '', ParserPower::UNESCAPE );
-		$token = ParserPower::expand( $frame, $params["token"] ?? '', ParserPower::UNESCAPE );
-		$tokenSep = ParserPower::expand( $frame, $params["tokensep"] ?? ',', ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params["pattern"] ?? '', ParserPower::NO_VARS );
-		$outSep = ParserPower::expand( $frame, $params["outsep"] ?? ',\_', ParserPower::UNESCAPE );
-		$countToken = ParserPower::expand( $frame, $params["counttoken"] ?? '', ParserPower::UNESCAPE );
-		$intro = ParserPower::expand( $frame, $params["intro"] ?? '', ParserPower::UNESCAPE );
-		$outro = ParserPower::expand( $frame, $params["outro"] ?? '', ParserPower::UNESCAPE );
+		$keepValues = $params->get( 'keep' );
+		$keepSep = $params->get( 'keepsep', [ 'default' => ',' ] );
+		$keepCS = $params->get( 'keepcs' );
+		$removeValues = $params->get( 'remove' );
+		$removeSep = $params->get( 'removesep', [ 'default' => ',' ] );
+		$removeCS = $params->get( 'removecs' );
+		$template = $params->get( 'template' );
+		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
+		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
+		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
+		$token = $params->get( 'token', [ 'unescape' => true ] );
+		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$pattern = $params->get( 'pattern' );
+		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
+		$intro = $params->get( 'intro', [ 'unescape' => true ] );
+		$outro = $params->get( 'outro', [ 'unescape' => true ] );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1062,23 +1062,23 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listuniqueRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParserPower::arrangeParams( $frame, $params );
+		$params = new ParameterArranger( $frame, $params );
 
-		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
-		$default = ParserPower::expand( $frame, $params["default"] ?? '', ParserPower::UNESCAPE );
+		$inList = $params->get( 'list' );
+		$default = $params->get( 'default', [ 'unescape' => true ] );
 
-		$uniqueCS = ParserPower::expand( $frame, $params["uniquecs"] ?? '' );
-		$template = ParserPower::expand( $frame, $params["template"] ?? '' );
-		$inSep = ParserPower::expand( $frame, $params["insep"] ?? ',', ParserPower::UNESCAPE );
-		$fieldSep = ParserPower::expand( $frame, $params["fieldsep"] ?? '', ParserPower::UNESCAPE );
-		$indexToken = ParserPower::expand( $frame, $params["indextoken"] ?? '', ParserPower::UNESCAPE );
-		$token = ParserPower::expand( $frame, $params["token"] ?? '', ParserPower::UNESCAPE );
-		$tokenSep = ParserPower::expand( $frame, $params["tokensep"] ?? ',', ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params["pattern"] ?? '' );
-		$outSep = ParserPower::expand( $frame, $params["outsep"] ?? ',\_', ParserPower::UNESCAPE );
-		$countToken = ParserPower::expand( $frame, $params["counttoken"] ?? '', ParserPower::UNESCAPE );
-		$intro = ParserPower::expand( $frame, $params["intro"] ?? '', ParserPower::UNESCAPE );
-		$outro = ParserPower::expand( $frame, $params["outro"] ?? '', ParserPower::UNESCAPE );
+		$uniqueCS = $params->get( 'uniquecs' );
+		$template = $params->get( 'template' );
+		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
+		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
+		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
+		$token = $params->get( 'token', [ 'unescape' => true ] );
+		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$pattern = $params->get( 'pattern' );
+		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
+		$intro = $params->get( 'intro', [ 'unescape' => true ] );
+		$outro = $params->get( 'outro', [ 'unescape' => true ] );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1312,26 +1312,26 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listsortRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParserPower::arrangeParams( $frame, $params );
+		$params = new ParameterArranger( $frame, $params );
 
-		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
-		$default = ParserPower::expand( $frame, $params["default"] ?? '', ParserPower::UNESCAPE );
+		$inList = $params->get( 'list' );
+		$default = $params->get( 'default', [ 'unescape' => true ] );
 
-		$template = ParserPower::expand( $frame, $params["template"] ?? '' );
-		$inSep = ParserPower::expand( $frame, $params["insep"] ?? ',', ParserPower::UNESCAPE );
-		$fieldSep = ParserPower::expand( $frame, $params["fieldsep"] ?? '', ParserPower::UNESCAPE );
-		$indexToken = ParserPower::expand( $frame, $params["indextoken"] ?? '', ParserPower::UNESCAPE );
-		$token = ParserPower::expand( $frame, $params["token"] ?? '', ParserPower::UNESCAPE );
-		$tokenSep = ParserPower::expand( $frame, $params["tokensep"] ?? ',', ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params["pattern"] ?? '' );
-		$outSep = ParserPower::expand( $frame, $params["outsep"] ?? ',\_', ParserPower::UNESCAPE );
-		$sortOptions = ParserPower::expand( $frame, $params["sortoptions"] ?? '' );
-		$subsort = ParserPower::expand( $frame, $params["subsort"] ?? '' );
-		$subsortOptions = ParserPower::expand( $frame, $params["subsortoptions"] ?? '' );
-		$duplicates = ParserPower::expand( $frame, $params["duplicates"] ?? '' );
-		$countToken = ParserPower::expand( $frame, $params["counttoken"] ?? '', ParserPower::UNESCAPE );
-		$intro = ParserPower::expand( $frame, $params["intro"] ?? '', ParserPower::UNESCAPE );
-		$outro = ParserPower::expand( $frame, $params["outro"] ?? '', ParserPower::UNESCAPE );
+		$template = $params->get( 'template' );
+		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
+		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
+		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
+		$token = $params->get( 'token', [ 'unescape' => true ] );
+		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$pattern = $params->get( 'pattern' );
+		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$sortOptions = $params->get( 'sortoptions' );
+		$subsort = $params->get( 'subsort' );
+		$subsortOptions = $params->get( 'subsortoptions' );
+		$duplicates = $params->get( 'duplicates' );
+		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
+		$intro = $params->get( 'intro', [ 'unescape' => true ] );
+		$outro = $params->get( 'outro', [ 'unescape' => true ] );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1610,25 +1610,25 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listmapRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParserPower::arrangeParams( $frame, $params );
+		$params = new ParameterArranger( $frame, $params );
 
-		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
-		$default = ParserPower::expand( $frame, $params["default"] ?? '', ParserPower::UNESCAPE );
+		$inList = $params->get( 'list' );
+		$default = $params->get( 'default', [ 'unescape' => true ] );
 
-		$template = ParserPower::expand( $frame, $params["template"] ?? '' );
-		$inSep = ParserPower::expand( $frame, $params["insep"] ?? ',', ParserPower::UNESCAPE );
-		$fieldSep = ParserPower::expand( $frame, $params["fieldsep"] ?? '', ParserPower::UNESCAPE );
-		$indexToken = ParserPower::expand( $frame, $params["indextoken"] ?? '', ParserPower::UNESCAPE );
-		$token = ParserPower::expand( $frame, $params["token"] ?? '', ParserPower::UNESCAPE );
-		$tokenSep = ParserPower::expand( $frame, $params["tokensep"] ?? ',', ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params["pattern"] ?? '' );
-		$outSep = ParserPower::expand( $frame, $params["outsep"] ?? ',\_', ParserPower::UNESCAPE );
-		$sortMode = ParserPower::expand( $frame, $params["sortmode"] ?? '' );
-		$sortOptions = ParserPower::expand( $frame, $params["sortoptions"] ?? '' );
-		$duplicates = ParserPower::expand( $frame, $params["duplicates"] ?? '' );
-		$countToken = ParserPower::expand( $frame, $params["counttoken"] ?? '', ParserPower::UNESCAPE );
-		$intro = ParserPower::expand( $frame, $params["intro"] ?? '', ParserPower::UNESCAPE );
-		$outro = ParserPower::expand( $frame, $params["outro"] ?? '', ParserPower::UNESCAPE );
+		$template = $params->get( 'template' );
+		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
+		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
+		$indexToken = $params->get( 'indextoken', [ 'unescape' => true ] );
+		$token = $params->get( 'token', [ 'unescape' => true ] );
+		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$pattern = $params->get( 'pattern' );
+		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$sortMode = $params->get( 'sortmode' );
+		$sortOptions = $params->get( 'sortoptions' );
+		$duplicates = $params->get( 'duplicates' );
+		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
+		$intro = $params->get( 'intro', [ 'unescape' => true ] );
+		$outro = $params->get( 'outro', [ 'unescape' => true ] );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -2101,26 +2101,26 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listmergeRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParserPower::arrangeParams( $frame, $params );
+		$params = new ParameterArranger( $frame, $params );
 
-		$inList = ParserPower::expand( $frame, $params["list"] ?? '' );
-		$default = ParserPower::expand( $frame, $params["default"] ?? '', ParserPower::UNESCAPE );
+		$inList = $params->get( 'list' );
+		$default = $params->get( 'default', [ 'unescape' => true ] );
 
-		$matchTemplate = ParserPower::expand( $frame, $params["matchtemplate"] ?? '' );
-		$mergeTemplate = ParserPower::expand( $frame, $params["mergetemplate"] ?? '' );
-		$inSep = ParserPower::expand( $frame, $params["insep"] ?? ',', ParserPower::UNESCAPE );
-		$fieldSep = ParserPower::expand( $frame, $params["fieldsep"] ?? '', ParserPower::UNESCAPE );
-		$token1 = ParserPower::expand( $frame, $params["token1"] ?? '', ParserPower::UNESCAPE );
-		$token2 = ParserPower::expand( $frame, $params["token2"] ?? '', ParserPower::UNESCAPE );
-		$tokenSep = ParserPower::expand( $frame, $params["tokensep"] ?? ',', ParserPower::UNESCAPE );
-		$matchPattern = ParserPower::expand( $frame, $params["matchpattern"] ?? '' );
-		$mergePattern = ParserPower::expand( $frame, $params["mergepattern"] ?? '' );
-		$outSep = ParserPower::expand( $frame, $params["outsep"] ?? ',\_', ParserPower::UNESCAPE );
-		$sortMode = ParserPower::expand( $frame, $params["sortmode"] ?? '' );
-		$sortOptions = ParserPower::expand( $frame, $params["sortoptions"] ?? '' );
-		$countToken = ParserPower::expand( $frame, $params["counttoken"] ?? '', ParserPower::UNESCAPE );
-		$intro = ParserPower::expand( $frame, $params["intro"] ?? '', ParserPower::UNESCAPE );
-		$outro = ParserPower::expand( $frame, $params["outro"] ?? '', ParserPower::UNESCAPE );
+		$matchTemplate = $params->get( 'matchtemplate' );
+		$mergeTemplate = $params->get( 'mergetemplate' );
+		$inSep = $params->get( 'insep', [ 'unescape' => true, 'default' => ',' ] );
+		$fieldSep = $params->get( 'fieldsep', [ 'unescape' => true ] );
+		$token1 = $params->get( 'token1', [ 'unescape' => true ] );
+		$token2 = $params->get( 'token2', [ 'unescape' => true ] );
+		$tokenSep = $params->get( 'tokensep', [ 'unescape' => true, 'default' => ',' ] );
+		$matchPattern = $params->get( 'matchpattern' );
+		$mergePattern = $params->get( 'mergepattern' );
+		$outSep = $params->get( 'outsep', [ 'unescape' => true, 'default' => ',\_' ] );
+		$sortMode = $params->get( 'sortmode' );
+		$sortOptions = $params->get( 'sortoptions' );
+		$countToken = $params->get( 'counttoken', [ 'unescape' => true ] );
+		$intro = $params->get( 'intro', [ 'unescape' => true ] );
+		$outro = $params->get( 'outro', [ 'unescape' => true ] );
 
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );

--- a/src/ParameterArranger.php
+++ b/src/ParameterArranger.php
@@ -25,8 +25,13 @@ final class ParameterArranger {
 	/**
 	 * @param PPFrame $frame Parser frame object.
 	 * @param array $params Parameters and values together, not yet expanded or trimmed.
+	 * @param array $paramOptions Parsing and post-processing options for all parameters.
 	 */
-	public function __construct( private readonly PPFrame $frame, array $params ) {
+	public function __construct(
+		private readonly PPFrame $frame,
+		array $params,
+		private array $paramOptions = []
+	) {
 		$this->params = [];
 
 		if ( isset( $params[0] ) && is_string( $params[0] ) ) {
@@ -54,7 +59,7 @@ final class ParameterArranger {
 	 * Get the expanded value of a parameter.
 	 *
 	 * @param int|string $key Parameter index or name.
-	 * @param array $options Parsing and post-processing options.
+	 * @param array $options Parsing and post-processing options, overriding the default ones if it has not already been parsed.
 	 * @return string The expanded (and post-processed) parameter value.
 	 */
 	public function get( int|string $key, array $options = [] ): string {
@@ -62,13 +67,14 @@ final class ParameterArranger {
 			return $this->expandedParams[$key];
 		}
 
-		$value = $this->params[$key] ?? $options['default'] ?? '';
+		$options = array_merge( $this->paramOptions[$key] ?? [], $options );
 
 		$flags = 0;
 		if ( $options['unescape'] ?? false ) {
 			$flags |= ParserPower::UNESCAPE;
 		}
 
+		$value = $this->params[$key] ?? $options['default'] ?? '';
 		$value = ParserPower::expand( $this->frame, $value, $flags );
 
 		$this->expandedParams[$key] = $value;

--- a/src/ParameterArranger.php
+++ b/src/ParameterArranger.php
@@ -1,0 +1,77 @@
+<?php
+
+/** @license GPL-2.0-or-later */
+
+namespace MediaWiki\Extension\ParserPower;
+
+use MediaWiki\Parser\PPFrame;
+
+/**
+ * Named parameter arranger for parser functions.
+ * Only evaluates parameter valuyes on use site, and applies some post-processings to parsed values,
+ * such as trimming whitespaces (as per longstanding MediaWiki conventions).
+ */
+final class ParameterArranger {
+
+	/**
+	 * Unexpanded parameters.
+	 */
+	private array $params;
+	/**
+	 * Expanded (and post-processed) parameters.
+	 */
+	private array $expandedParams = [];
+
+	/**
+	 * @param PPFrame $frame Parser frame object.
+	 * @param array $params Parameters and values together, not yet expanded or trimmed.
+	 */
+	public function __construct( private readonly PPFrame $frame, array $params ) {
+		$this->params = [];
+
+		if ( isset( $params[0] ) && is_string( $params[0] ) ) {
+			$pair = explode( '=', array_shift( $params ), 2 );
+			if ( count( $pair ) === 2 ) {
+				$key = ParserPower::expand( $this->frame, $pair[0] );
+				$this->params[$key] = $pair[1];
+			} else {
+				$this->params[] = $pair[0];
+			}
+		}
+
+		foreach ( $params as $param ) {
+			$bits = $param->splitArg();
+			if ( $bits['index'] === '' ) {
+				$key = ParserPower::expand( $this->frame, $bits['name'] );
+				$this->params[$key] = $bits['value'];
+			} else {
+				$this->params[] = $bits['value'];
+			}
+		}
+	}
+
+	/**
+	 * Get the expanded value of a parameter.
+	 *
+	 * @param int|string $key Parameter index or name.
+	 * @param array $options Parsing and post-processing options.
+	 * @return string The expanded (and post-processed) parameter value.
+	 */
+	public function get( int|string $key, array $options = [] ): string {
+		if ( isset( $this->expandedParams[$key] ) ) {
+			return $this->expandedParams[$key];
+		}
+
+		$value = $this->params[$key] ?? $options['default'] ?? '';
+
+		$flags = 0;
+		if ( $options['unescape'] ?? false ) {
+			$flags |= ParserPower::UNESCAPE;
+		}
+
+		$value = ParserPower::expand( $this->frame, $value, $flags );
+
+		$this->expandedParams[$key] = $value;
+		return $value;
+	}
+}

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -59,48 +59,6 @@ class ParserPower {
 	];
 
 	/**
-	 * This function converts the parameters to the parser function into an array form with all parameter values
-	 * trimmed, as per longstanding MediaWiki conventions.
-	 *
-	 * @param PPFrame $frame The parser frame object.
-	 * @param array $unexpandedParams The parameters and values together, not yet exploded or trimmed.
-	 * @return array The parameter values associated with the appropriate named or numbered keys
-	 */
-	public static function arrangeParams( PPFrame $frame, array $unexpandedParams ): array {
-		$params = [];
-
-		if ( isset( $unexpandedParams[0] ) && is_string( $unexpandedParams[0] ) ) {
-			$pair = explode( '=', array_shift( $unexpandedParams ), 2 );
-			if ( count( $pair ) === 2 ) {
-				$params[trim( $pair[0] )] = trim( $pair[1] );
-			} else {
-				$params[] = trim( $pair[0] );
-			}
-		}
-
-		foreach ( $unexpandedParams as $unexpandedParam ) {
-			$bits = $unexpandedParam->splitArg();
-			if ( $bits['index'] === '' ) {
-				$params[self::expand( $frame, $bits['name'] )] = $bits['value'];
-			} else {
-				$params[] = $bits['value'];
-			}
-		}
-
-		return $params;
-	}
-
-	/**
-	 * The function returns tests a value to see that isn't null or an empty string.
-	 *
-	 * @param string $value The value to check.
-	 * @return bool true for a value that is not null or an empty string.
-	 */
-	public static function isEmpty( string $value ): bool {
-		return $value === null || $value === '';
-	}
-
-	/**
 	 * Expands and trims a PPNode.
 	 *
 	 * @param PPFrame $frame


### PR DESCRIPTION
## Current state

To parse named arguments, parser functions use a `ParserPower::arrangeParams` function, that expands parameter keys, and maps keys to (unexpanded) values. Then, parameter values can be expanded and post-processed with a `ParserPower::expand` function. E.g.:

```php
$params = ParserPower::expand( $frame, $rawParams );

$value1 = ParserPower::expand( $frame, $params["key1"] ?? 'no' );
$value2 = ParserPower::expand( $frame, $params["key2"] ?? '', ParserPower::UNESCAPE );
```

## Proposed changes

Instead of `ParserPower::arrangeParams`, define a separate `ParameterArranger` class to encapsulate all these steps. Construct it from a parameter configuration array, so we can `get()` the same parameter multiple times without having to duplicate all its parsing information.

```php
$params = new ParameterArranger( $frame, $rawParams, [
	'key1' => [ 'default' => 'no' ],
	'key1' => [ 'unescape' => true ],
] );

$value1 = $params->get( 'key1' );
$value2 = $params->get( 'key2' );
```

This would help with making functions lazier in the future, and since all parser functions share the same parsing steps for parameters with the same name, we can merge parsing info for all parameters of all functions in a single large array (`ListFunctions::PARAM_OPTIONS`).