### PR TITLE
refactor: Replace `explodeList` and `arrayTrimUnescape` with dedicated `explode...` functions

### DIFF
--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -260,6 +260,22 @@ final class ListFunctions {
 	}
 
 	/**
+	 * Split a token into an array by a given delimiter.
+	 * Whitespaces are trimmed from the end of each token.
+	 *
+	 * @param string $sep Delimiter used to separate the tokens.
+	 * @param string $token Token to split.
+	 * @return array The tokens, in an array of strings.
+	 */
+	private static function explodeToken( string $sep, string $token ): array {
+		if ( $sep === '' ) {
+			return [ trim( $token ) ];
+		} else {
+			return array_map( 'trim', explode( $sep, $token ) );
+		}
+	}
+
+	/**
 	 * Slice an array according to the specified 1-based offset and length.
 	 *
 	 * @param array $values Array to slice.
@@ -712,7 +728,7 @@ final class ListFunctions {
 	): array {
 		$outValues = [];
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
-			$tokens = array_map( 'trim', explode( $tokenSep, $token ) );
+			$tokens = self::explodeToken( $tokenSep, $token );
 			$tokenCount = count( $tokens );
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 			foreach ( $inValues as $i => $value ) {
@@ -1096,7 +1112,7 @@ final class ListFunctions {
 		$inValues = self::explodeList( $inSep, $inList );
 
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
-			$tokens = array_map( 'trim', explode( $tokenSep, $token ) );
+			$tokens = self::explodeToken( $tokenSep, $token );
 		}
 
 		if ( $template !== '' ) {
@@ -1361,7 +1377,7 @@ final class ListFunctions {
 		}
 
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
-			$tokens = array_map( 'trim', explode( $tokenSep, $token ) );
+			$tokens = self::explodeToken( $tokenSep, $token );
 		}
 
 		if ( $template !== '' || ( ( $indexToken !== '' || $token !== '' ) && $pattern !== '' ) ) {
@@ -1483,7 +1499,7 @@ final class ListFunctions {
 
 		$outValues = [];
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
-			$tokens = array_map( 'trim', explode( $tokenSep, $token ) );
+			$tokens = self::explodeToken( $tokenSep, $token );
 			$tokenCount = count( $tokens );
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 			foreach ( $inValues as $i => $inValue ) {
@@ -1993,8 +2009,8 @@ final class ListFunctions {
 		}
 
 		if ( $tokenSep !== '' ) {
-			$tokens1 = array_map( 'trim', explode( $tokenSep, $token1 ) );
-			$tokens2 = array_map( 'trim', explode( $tokenSep, $token2 ) );
+			$tokens1 = self::explodeToken( $tokenSep, $token1 );
+			$tokens2 = self::explodeToken( $tokenSep, $token2 );
 		} else {
 			$tokens1 = [ $token1 ];
 			$tokens2 = [ $token2 ];

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -726,7 +726,7 @@ final class ListFunctions {
 		string $tokenSep,
 		string $pattern
 	): array {
-		if ( $fieldSep !== '' && $tokenSep !== '' ) {
+		if ( $fieldSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
 		} else {
 			$tokens = [ $token ];
@@ -1078,7 +1078,7 @@ final class ListFunctions {
 
 		$inValues = self::explodeList( $inSep, $inList );
 
-		if ( $fieldSep !== '' && $tokenSep !== '' ) {
+		if ( $fieldSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
 		}
 
@@ -1332,7 +1332,7 @@ final class ListFunctions {
 			$values = array_unique( $values );
 		}
 
-		if ( $fieldSep !== '' && $tokenSep !== '' ) {
+		if ( $fieldSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
 		}
 
@@ -1453,7 +1453,7 @@ final class ListFunctions {
 			$inValues = $sorter->sort( $inValues );
 		}
 
-		if ( $fieldSep !== '' && $tokenSep !== '' ) {
+		if ( $fieldSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
 		} else {
 			$tokens = [ $token ];
@@ -1944,13 +1944,8 @@ final class ListFunctions {
 			$inValues = $sorter->sort( $inValues );
 		}
 
-		if ( $tokenSep !== '' ) {
-			$tokens1 = self::explodeToken( $tokenSep, $token1 );
-			$tokens2 = self::explodeToken( $tokenSep, $token2 );
-		} else {
-			$tokens1 = [ $token1 ];
-			$tokens2 = [ $token2 ];
-		}
+		$tokens1 = self::explodeToken( $tokenSep, $token1 );
+		$tokens2 = self::explodeToken( $tokenSep, $token2 );
 
 		$matchParams = [ $parser, $frame, '', '', $fieldSep, $tokens1, $tokens2, $matchPattern ];
 		$mergeParams = [ $parser, $frame, '', '', $fieldSep, $tokens1, $tokens2, $mergePattern ];

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -10,6 +10,7 @@ use MediaWiki\Extension\ParserPower\Operation\PatternOperation;
 use MediaWiki\Extension\ParserPower\Operation\TemplateOperation;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
+use StringUtils;
 
 final class ListFunctions {
 	/**
@@ -223,9 +224,9 @@ final class ListFunctions {
 	 */
 	private static function explodeList( string $sep, string $list ): array {
 		if ( $sep === '' ) {
-			$inValues = preg_split( '/(.)/u', $list, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE );
+			$inValues = preg_split( '/(?<!^)(?!$)/u', $list );
 		} else {
-			$inValues = explode( $sep, $list );
+			$inValues = StringUtils::explode( $sep, $list );
 		}
 
 		if ( $inValues === false ) {

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -726,27 +726,22 @@ final class ListFunctions {
 		string $tokenSep,
 		string $pattern
 	): array {
-		$outValues = [];
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
-			$tokenCount = count( $tokens );
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
-			foreach ( $inValues as $i => $value ) {
-				if ( $value !== '' ) {
-					$result = $operation->apply( self::explodeValue( $fieldSep, $value, $tokenCount ), $i + 1 );
-					if ( strtolower( $result ) !== 'remove' ) {
-						$outValues[] = $value;
-					}
-				}
-			}
+			$fieldLimit = count( $tokens );
 		} else {
-			$operation = new PatternOperation( $parser, $frame, $pattern, [ $token ], $indexToken );
-			foreach ( $inValues as $i => $value ) {
-				if ( $value !== '' ) {
-					$result = $operation->apply( [ $value ], $i + 1 );
-					if ( strtolower( $result ) !== 'remove' ) {
-						$outValues[] = $value;
-					}
+			$tokens = [ $token ];
+			$fieldLimit = 1;
+		}
+
+		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+
+		$outValues = [];
+		foreach ( $inValues as $i => $value ) {
+			if ( $value !== '' ) {
+				$result = $operation->apply( self::explodeValue( $fieldSep, $value, $fieldLimit ), $i + 1 );
+				if ( strtolower( $result ) !== 'remove' ) {
+					$outValues[] = $value;
 				}
 			}
 		}
@@ -774,19 +769,10 @@ final class ListFunctions {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		$outValues = [];
-		if ( $fieldSep === '' ) {
-			foreach ( $inValues as $value ) {
-				$result = $operation->apply( [ $value ] );
-				if ( $value !== '' && strtolower( $result ) !== 'remove' ) {
-					$outValues[] = $value;
-				}
-			}
-		} else {
-			foreach ( $inValues as $value ) {
-				$result = $operation->apply( self::explodeValue( $fieldSep, $value ) );
-				if ( $value !== '' && strtolower( $result ) !== 'remove' ) {
-					$outValues[] = $value;
-				}
+		foreach ( $inValues as $value ) {
+			$result = $operation->apply( self::explodeValue( $fieldSep, $value ) );
+			if ( $value !== '' && strtolower( $result ) !== 'remove' ) {
+				$outValues[] = $value;
 			}
 		}
 
@@ -1001,29 +987,23 @@ final class ListFunctions {
 		?array $tokens,
 		string $pattern
 	): array {
+		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
+			$fieldLimit = count( $tokens );
+		} else {
+			$tokens = [ $token ];
+			$fieldLimit = 1;
+		}
+
+		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+
 		$previousKeys = [];
 		$outValues = [];
-		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
-			$tokenCount = count( $tokens );
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
-			foreach ( $inValues as $i => $value ) {
-				if ( $value !== '' ) {
-					$key = $operation->apply( self::explodeValue( $fieldSep, $value, $tokenCount ), $i + 1 );
-					if ( !in_array( $key, $previousKeys ) ) {
-						$previousKeys[] = $key;
-						$outValues[] = $value;
-					}
-				}
-			}
-		} else {
-			$operation = new PatternOperation( $parser, $frame, $pattern, [ $token ], $indexToken );
-			foreach ( $inValues as $i => $value ) {
-				if ( $value !== '' ) {
-					$key = $operation->apply( [ $value ], $i + 1 );
-					if ( !in_array( $key, $previousKeys ) ) {
-						$previousKeys[] = $key;
-						$outValues[] = $value;
-					}
+		foreach ( $inValues as $i => $value ) {
+			if ( $value !== '' ) {
+				$key = $operation->apply( self::explodeValue( $fieldSep, $value, $fieldLimit ), $i + 1 );
+				if ( !in_array( $key, $previousKeys ) ) {
+					$previousKeys[] = $key;
+					$outValues[] = $value;
 				}
 			}
 		}
@@ -1054,21 +1034,11 @@ final class ListFunctions {
 
 		$previousKeys = [];
 		$outValues = [];
-		if ( $fieldSep === '' ) {
-			foreach ( $inValues as $value ) {
-				$key = $operation->apply( [ $value ] );
-				if ( !in_array( $key, $previousKeys ) ) {
-					$previousKeys[] = $key;
-					$outValues[] = $value;
-				}
-			}
-		} else {
-			foreach ( $inValues as $value ) {
-				$key = $operation->apply( self::explodeValue( $fieldSep, $value ) );
-				if ( !in_array( $key, $previousKeys ) ) {
-					$previousKeys[] = $key;
-					$outValues[] = $value;
-				}
+		foreach ( $inValues as $value ) {
+			$key = $operation->apply( self::explodeValue( $fieldSep, $value ) );
+			if ( !in_array( $key, $previousKeys ) ) {
+				$previousKeys[] = $key;
+				$outValues[] = $value;
 			}
 		}
 
@@ -1187,23 +1157,20 @@ final class ListFunctions {
 		?array $tokens,
 		string $pattern
 	): array {
-		$pairedValues = [];
 		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
-			$tokenCount = count( $tokens );
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
-			foreach ( $values as $i => $value ) {
-				if ( $value !== '' ) {
-					$key = $operation->apply( self::explodeValue( $fieldSep, $value, $tokenCount ), $i + 1 );
-					$pairedValues[] = [ $key, $value ];
-				}
-			}
+			$fieldLimit = count( $tokens );
 		} else {
-			$operation = new PatternOperation( $parser, $frame, $pattern, [ $token ], $indexToken );
-			foreach ( $values as $i => $value ) {
-				if ( $value !== '' ) {
-					$key = $operation->apply( [ $value ], $i + 1 );
-					$pairedValues[] = [ $key, $value ];
-				}
+			$tokens = [ $token ];
+			$fieldLimit = 1;
+		}
+
+		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+
+		$pairedValues = [];
+		foreach ( $values as $i => $value ) {
+			if ( $value !== '' ) {
+				$key = $operation->apply( self::explodeValue( $fieldSep, $value, $fieldLimit ), $i + 1 );
+				$pairedValues[] = [ $key, $value ];
 			}
 		}
 
@@ -1232,14 +1199,8 @@ final class ListFunctions {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		$pairedValues = [];
-		if ( $fieldSep === '' ) {
-			foreach ( $values as $value ) {
-				$pairedValues[] = [ $operation->apply( [ $value ] ), $value ];
-			}
-		} else {
-			foreach ( $values as $value ) {
-				$pairedValues[] = [ $operation->apply( self::explodeValue( $fieldSep, $value ) ), $value ];
-			}
+		foreach ( $values as $value ) {
+			$pairedValues[] = [ $operation->apply( self::explodeValue( $fieldSep, $value ) ), $value ];
 		}
 
 		return $pairedValues;
@@ -1497,27 +1458,22 @@ final class ListFunctions {
 			$inValues = $sorter->sort( $inValues );
 		}
 
-		$outValues = [];
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
-			$tokenCount = count( $tokens );
-			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
-			foreach ( $inValues as $i => $inValue ) {
-				if ( $inValue !== '' ) {
-					$outValue = $operation->apply( self::explodeValue( $fieldSep, $inValue, $tokenCount ), $i + 1 );
-					if ( $outValue !== '' ) {
-						$outValues[] = $outValue;
-					}
-				}
-			}
+			$fieldLimit = count( $tokens );
 		} else {
-			$operation = new PatternOperation( $parser, $frame, $pattern, [ $token ], $indexToken );
-			foreach ( $inValues as $i => $inValue ) {
-				if ( $inValue !== '' ) {
-					$outValue = $operation->apply( [ $inValue ], $i + 1 );
-					if ( $outValue !== '' ) {
-						$outValues[] = $outValue;
-					}
+			$tokens = [ $token ];
+			$fieldLimit = 1;
+		}
+
+		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+
+		$outValues = [];
+		foreach ( $inValues as $i => $inValue ) {
+			if ( $inValue !== '' ) {
+				$outValue = $operation->apply( self::explodeValue( $fieldSep, $inValue, $fieldLimit ), $i + 1 );
+				if ( $outValue !== '' ) {
+					$outValues[] = $outValue;
 				}
 			}
 		}
@@ -1596,14 +1552,8 @@ final class ListFunctions {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
 		$outValues = [];
-		if ( $fieldSep === '' ) {
-			foreach ( $inValues as $inValue ) {
-				$outValues[] = $operation->apply( [ $inValue ] );
-			}
-		} else {
-			foreach ( $inValues as $inValue ) {
-				$outValues[] = $operation->apply( self::explodeValue( $fieldSep, $inValue ) );
-			}
+		foreach ( $inValues as $inValue ) {
+			$outValues[] = $operation->apply( self::explodeValue( $fieldSep, $inValue ) );
 		}
 
 		if ( $sortMode & ( self::SORTMODE_POST | self::SORTMODE_COMPAT ) ) {
@@ -1844,13 +1794,9 @@ final class ListFunctions {
 			return '';
 		}
 
-		if ( $fieldSep === '' ) {
-			$fields = [ $inValue1, $tokenCount1 => $inValue2 ];
-		} else {
-			$fields = self::explodeValue( $fieldSep, $inValue1, $tokenCount1 );
-			foreach ( self::explodeValue( $fieldSep, $inValue1, $tokenCount2 ) as $i => $field ) {
-				$fields[$tokenCount1 + $i] = $field;
-			}
+		$fields = self::explodeValue( $fieldSep, $inValue1, $tokenCount1 );
+		foreach ( self::explodeValue( $fieldSep, $inValue2, $tokenCount2 ) as $i => $field ) {
+			$fields[$tokenCount1 + $i] = $field;
 		}
 
 		return $operation->apply( $fields );
@@ -1878,14 +1824,10 @@ final class ListFunctions {
 	): string {
 		$operation = new TemplateOperation( $parser, $frame, $template );
 
-		if ( $fieldSep === '' ) {
-			return $operation->apply( [ $inValue1, $inValue2 ] );
-		} else {
-			return $operation->apply( [
-				...self::explodeValue( $fieldSep, $inValue1 ),
-				...self::explodeValue( $fieldSep, $inValue2 )
-			] );
-		}
+		return $operation->apply( [
+			...self::explodeValue( $fieldSep, $inValue1 ),
+			...self::explodeValue( $fieldSep, $inValue2 )
+		] );
 	}
 
 	/**

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -728,13 +728,12 @@ final class ListFunctions {
 	): array {
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
-			$fieldLimit = count( $tokens );
 		} else {
 			$tokens = [ $token ];
-			$fieldLimit = 1;
 		}
 
 		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+		$fieldLimit = $operation->getFieldLimit();
 
 		$outValues = [];
 		foreach ( $inValues as $i => $value ) {
@@ -987,14 +986,12 @@ final class ListFunctions {
 		?array $tokens,
 		string $pattern
 	): array {
-		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
-			$fieldLimit = count( $tokens );
-		} else {
+		if ( $tokens === null ) {
 			$tokens = [ $token ];
-			$fieldLimit = 1;
 		}
 
 		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+		$fieldLimit = $operation->getFieldLimit();
 
 		$previousKeys = [];
 		$outValues = [];
@@ -1157,14 +1154,12 @@ final class ListFunctions {
 		?array $tokens,
 		string $pattern
 	): array {
-		if ( ( isset( $tokens ) && is_array( $tokens ) ) ) {
-			$fieldLimit = count( $tokens );
-		} else {
+		if ( $tokens === null ) {
 			$tokens = [ $token ];
-			$fieldLimit = 1;
 		}
 
 		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+		$fieldLimit = $operation->getFieldLimit();
 
 		$pairedValues = [];
 		foreach ( $values as $i => $value ) {
@@ -1460,13 +1455,12 @@ final class ListFunctions {
 
 		if ( $fieldSep !== '' && $tokenSep !== '' ) {
 			$tokens = self::explodeToken( $tokenSep, $token );
-			$fieldLimit = count( $tokens );
 		} else {
 			$tokens = [ $token ];
-			$fieldLimit = 1;
 		}
 
 		$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
+		$fieldLimit = $operation->getFieldLimit();
 
 		$outValues = [];
 		foreach ( $inValues as $i => $inValue ) {

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -244,6 +244,22 @@ final class ListFunctions {
 	}
 
 	/**
+	 * Split a list value into an array of fields by a given delimiter.
+	 *
+	 * @param string $sep Delimiter used to separate the fields.
+	 * @param string $value Value to split.
+	 * @param ?int $fieldLimit Maximum number of fields, null if there is no upper bound.
+	 * @return array The fields, in an array of strings.
+	 */
+	private static function explodeValue( string $sep, string $value, ?int $fieldLimit = null ): array {
+		if ( $sep === '' ) {
+			return [ $value ];
+		} else {
+			return explode( $sep, $value, $fieldLimit ?? PHP_INT_MAX );
+		}
+	}
+
+	/**
 	 * Slice an array according to the specified 1-based offset and length.
 	 *
 	 * @param array $values Array to slice.
@@ -701,7 +717,7 @@ final class ListFunctions {
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 			foreach ( $inValues as $i => $value ) {
 				if ( $value !== '' ) {
-					$result = $operation->apply( explode( $fieldSep, $value, $tokenCount ), $i + 1 );
+					$result = $operation->apply( self::explodeValue( $fieldSep, $value, $tokenCount ), $i + 1 );
 					if ( strtolower( $result ) !== 'remove' ) {
 						$outValues[] = $value;
 					}
@@ -751,7 +767,7 @@ final class ListFunctions {
 			}
 		} else {
 			foreach ( $inValues as $value ) {
-				$result = $operation->apply( explode( $fieldSep, $value ) );
+				$result = $operation->apply( self::explodeValue( $fieldSep, $value ) );
 				if ( $value !== '' && strtolower( $result ) !== 'remove' ) {
 					$outValues[] = $value;
 				}
@@ -976,7 +992,7 @@ final class ListFunctions {
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 			foreach ( $inValues as $i => $value ) {
 				if ( $value !== '' ) {
-					$key = $operation->apply( explode( $fieldSep, $value, $tokenCount ), $i + 1 );
+					$key = $operation->apply( self::explodeValue( $fieldSep, $value, $tokenCount ), $i + 1 );
 					if ( !in_array( $key, $previousKeys ) ) {
 						$previousKeys[] = $key;
 						$outValues[] = $value;
@@ -1032,7 +1048,7 @@ final class ListFunctions {
 			}
 		} else {
 			foreach ( $inValues as $value ) {
-				$key = $operation->apply( explode( $fieldSep, $value ) );
+				$key = $operation->apply( self::explodeValue( $fieldSep, $value ) );
 				if ( !in_array( $key, $previousKeys ) ) {
 					$previousKeys[] = $key;
 					$outValues[] = $value;
@@ -1161,7 +1177,7 @@ final class ListFunctions {
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 			foreach ( $values as $i => $value ) {
 				if ( $value !== '' ) {
-					$key = $operation->apply( explode( $fieldSep, $value, $tokenCount ), $i + 1 );
+					$key = $operation->apply( self::explodeValue( $fieldSep, $value, $tokenCount ), $i + 1 );
 					$pairedValues[] = [ $key, $value ];
 				}
 			}
@@ -1206,7 +1222,7 @@ final class ListFunctions {
 			}
 		} else {
 			foreach ( $values as $value ) {
-				$pairedValues[] = [ $operation->apply( explode( $fieldSep, $value ) ), $value ];
+				$pairedValues[] = [ $operation->apply( self::explodeValue( $fieldSep, $value ) ), $value ];
 			}
 		}
 
@@ -1472,7 +1488,7 @@ final class ListFunctions {
 			$operation = new PatternOperation( $parser, $frame, $pattern, $tokens, $indexToken );
 			foreach ( $inValues as $i => $inValue ) {
 				if ( $inValue !== '' ) {
-					$outValue = $operation->apply( explode( $fieldSep, $inValue, $tokenCount ), $i + 1 );
+					$outValue = $operation->apply( self::explodeValue( $fieldSep, $inValue, $tokenCount ), $i + 1 );
 					if ( $outValue !== '' ) {
 						$outValues[] = $outValue;
 					}
@@ -1570,7 +1586,7 @@ final class ListFunctions {
 			}
 		} else {
 			foreach ( $inValues as $inValue ) {
-				$outValues[] = $operation->apply( explode( $fieldSep, $inValue ) );
+				$outValues[] = $operation->apply( self::explodeValue( $fieldSep, $inValue ) );
 			}
 		}
 
@@ -1815,8 +1831,8 @@ final class ListFunctions {
 		if ( $fieldSep === '' ) {
 			$fields = [ $inValue1, $tokenCount1 => $inValue2 ];
 		} else {
-			$fields = explode( $fieldSep, $inValue1, $tokenCount1 );
-			foreach ( explode( $fieldSep, $inValue1, $tokenCount2 ) as $i => $field ) {
+			$fields = self::explodeValue( $fieldSep, $inValue1, $tokenCount1 );
+			foreach ( self::explodeValue( $fieldSep, $inValue1, $tokenCount2 ) as $i => $field ) {
 				$fields[$tokenCount1 + $i] = $field;
 			}
 		}
@@ -1849,7 +1865,10 @@ final class ListFunctions {
 		if ( $fieldSep === '' ) {
 			return $operation->apply( [ $inValue1, $inValue2 ] );
 		} else {
-			return $operation->apply( [ ...explode( $fieldSep, $inValue1 ), ...explode( $fieldSep, $inValue2 ) ] );
+			return $operation->apply( [
+				...self::explodeValue( $fieldSep, $inValue1 ),
+				...self::explodeValue( $fieldSep, $inValue2 )
+			] );
 		}
 	}
 


### PR DESCRIPTION
## Context

Parser functions split lists of 4 different forms:
1. Flags (e.g. `sortoptions`):
   - values are space-separated.
2. Values (from a list):
   - separator is used-defined (`insep`), no separator means each character is a list value,
   - values are trimmed, unescaped, and empty ones are removed.
3. Fields (from a value):
   - separator is user-defined (`fieldsep`),
   - can have a limit of extracted fields.
4. Tokens:
   - separator is user-defined (`tokensep`),
   - tokens are trimmed.

## Current status

1. Flags are split using dedicated functions, such as `decodeSortOptions` or `decodeIndexOptions`.
2. Values are split using `explodeList` then post-processed using either `arrayTrimUnescape` or `arrayElementTrimUnescape`.
3. Fields are split without a dedicated function (checks for empty separators + `explode` on use site).
4. Tokens are split without a dedicated function (checks for empty separators + `explode` + `array_map(trim,` on use site).

## Proposed changes

- Make `explodeList` do all post-processings for values.
- Replace `arrayTrimUnescape`/`arrayElementTrimUnescape` with  `arraySlice`/`arrayElement` that only do their 1-based indexing.
- Add `explodeValue` and `explodeToken` to split fields and tokens (respectively).

So we have:

1. Flags are split using dedicated functions, such as `decodeSortOptions` or `decodeIndexOptions`.
2. Values are split using `explodeList`.
3. Fields are split using `explodeValue`.
4. Tokens are split using `explodeToken`.