### PR TITLE
List functions: Provide an `{{{index}}}` parameter to template calls

### DIFF
--- a/src/Operation/TemplateOperation.php
+++ b/src/Operation/TemplateOperation.php
@@ -37,6 +37,9 @@ final class TemplateOperation implements WikitextOperation {
 		foreach ( $fields as $i => $value ) {
 			$result .= '|' . ( $i + 1 ) . '=' . $value;
 		}
+		if ( $index !== null ) {
+			$result .= '|index=' . $index;
+		}
 		$result .= '}}';
 
 		return ParserPower::evaluateUnescaped( $this->parser, $this->frame, $result, ParserPower::WITH_ARGS );

--- a/tests/parser/listFunctionsTest.txt
+++ b/tests/parser/listFunctionsTest.txt
@@ -55,6 +55,12 @@ KeEP
 !! endarticle
 
 !! article
+Template:Remove/if index
+!! text
+{{#switch: {{{index}}} | 2 | 6 | 7 | 10 = rEMovE }}
+!! endarticle
+
+!! article
 Template:Remove/if value
 !! text
 {{#switch: {{{1}}} | b | f | g | j = rEMovE }}
@@ -67,15 +73,33 @@ Template:Remove/if fields
 !! endarticle
 
 !! article
+Template:Unique/index
+!! text
+{{#expr: trunc( {{{index}}} / 2 ) }}
+!! endarticle
+
+!! article
 Template:Unique/value
 !! text
 {{#switch: {{{1}}} | b | c | f = x | {{{1}}} }}
 !! endarticle
 
 !! article
+Template:Sort/index
+!! text
+{{#expr: 10 - {{{index}}} }}
+!! endarticle
+
+!! article
 Template:Sort/value
 !! text
 {{#switch: {{lc: {{{1}}} }} | a = 3 | c = 2 | 1 }}
+!! endarticle
+
+!! article
+Template:Map/index
+!! text
+{{#expr: {{{index}}} mod 3 }}
 !! endarticle
 
 !! article
@@ -466,6 +490,7 @@ cs desc neg: "-3" / ""
 "{{#listfilter: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = unknown }}"
 "{{#listfilter: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = remove/keep }}"
 "{{#listfilter: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = remove }}"
+"{{#listfilter: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = remove/if index }}"
 "{{#listfilter: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = remove/if value }}"
 "{{#listfilter: list = a:k, b :l ,c: m,:n,d :o:,e:p: p, ,f:q :r, g : s | template = remove/if fields | fieldsep = : }}"
 !! html/php
@@ -473,6 +498,7 @@ cs desc neg: "-3" / ""
 "a, b, c, d, e, f, g, h, i, j"
 "a, b, c, d, e, f, g, h, i, j"
 ""
+"a, c, d, e, h, i"
 "a, c, d, e, h, i"
 "a:k, b :l, c: m, d :o:, e:p: p, f:q :r, g&#160;: s"
 </p>
@@ -626,10 +652,12 @@ cs desc neg: "-3" / ""
 !! wikitext
 "{{#listunique: list = a, b ,C,D,,A ,b, ,c, D,E,f | template = empty }}"
 "{{#listunique: list = a, b ,C,D,,A ,b, ,c, D,E,f | template = unknown }}"
+"{{#listunique: list = a, b ,C,D,,A ,b, ,c, D,E,f | template = unique/index }}"
 "{{#listunique: list = a, b ,C,D,,A ,b, ,c, D,E,f | template = unique/value }}"
 !! html/php
 <p>"a"
 "a"
+"a, b, D, b, D, f"
 "a, b, C, D, A, E"
 </p>
 !! end
@@ -698,10 +726,12 @@ cs desc neg: "-3" / ""
 !! wikitext
 "{{#listsort: list = f, D ,C,A,,F ,B, ,e, a,c,C | template = empty }}"
 "{{#listsort: list = f, D ,C,A,,F ,B, ,e, a,c,C | template = unknown }}"
+"{{#listsort: list = f, D ,C,A,,F ,B, ,e, a,c,C | template = sort/index }}"
 "{{#listsort: list = f, D ,C,A,,F ,B, ,e, a,c,C | template = sort/value }}"
 !! html/php
 <p>"f, D, C, A, F, B, e, a, c, C"
 "f, D, C, A, F, B, e, a, c, C"
+"C, c, a, e, B, F, A, C, D, f"
 "f, D, F, B, e, C, c, C, A, a"
 </p>
 !! end
@@ -812,10 +842,12 @@ numeric desc: "6!6!4!4!3!3!3!2!1!1"
 !! wikitext
 "{{#listmap: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = empty }}"
 "{{#listmap: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = unknown }}"
+"{{#listmap: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = map/index }}"
 "{{#listmap: list = a, b ,c,d,,e ,f, ,g, h,i,j | template = map/value }}"
 !! html/php
 <p>", , , , , , , , , "
 "x y, x y, x y, x y, x y, x y, x y, x y, x y, x y"
+"1, 2, 0, 1, 2, 0, 1, 2, 0, 1"
 "a, -b, c, d, e, -f, -g, h, i, -j"
 </p>
 !! end
@@ -934,6 +966,7 @@ numeric desc: "6!6!4!4!3!3!3!2!1!1"
 !! wikitext
 "{{#lstmaptemp:}}"
 "{{#lstmaptemp: 5, 6 ,7,8,,9 ,0, ,1, 2,3,4 }}"
+"{{#lstmaptemp: 5, 6 ,7,8,,9 ,0, ,1, 2,3,4 | map/index }}"
 "{{#lstmaptemp: 5, 6 ,7,8,,9 ,0, ,1, 2,3,4 | opposite }}"
 "{{#lstmaptemp: 5; 6 ;7;8;;9 ;0; ;1; 2;3;4 | opposite | ; }}"
 "{{#lstmaptemp: 5; 6 ;7;8;;9 ;0; ;1; 2;3;4 | opposite | ; | ! }}"
@@ -946,6 +979,7 @@ numeric desc: "6!6!4!4!3!3!3!2!1!1"
 !! html/php
 <p>""
 "5, 6, 7, 8, 9, 0, 1, 2, 3, 4"
+"1, 2, 0, 1, 2, 0, 1, 2, 0, 1"
 "4, 3, 2, 1, 0, 9, 8, 7, 6, 5"
 "4, 3, 2, 1, 0, 9, 8, 7, 6, 5"
 "4!3!2!1!0!9!8!7!6!5"


### PR DESCRIPTION
## Current state

Some list parser functions apply a pattern to their input list values, this includes:
- `#listfilter`,
- `#listunique` when both `|token=` or `|indextoken=` and `|pattern=` are specified and non-empty,
- `#listsort` when both `|token=` or `|indextoken=` and `|pattern=` are specified and non-empty,
- `#listmap`,
- `#lstmap`,
- `#listmerge`.

Some list parser functions can (alternatively) transclude a template (instead of replacing tokens in a pattern):
- `#listfilter` when `|template=` is specified and non-empty,
- `#listunique` when `|template=` is specified and non-empty,
- `#listsort` when `|template=` is specified and non-empty,
- `#listmap` when `|template=` is specified and non-empty,
- `#lstmaptemp`,
- `#listmerge` when both `|matchtemplate=` and `|mergetemplate=` are specified and non-empty.

When providing a pattern, an `|indextoken=` parameter can be provided to be replaced with the 1-based list value index. This does not apply to `#lstmap` (it provides a reduced set of arguments, excluding `indextoken`) and `#listmerge` (value indices are expected to change unpredictably during the function execution).

For exemple, we can filter out even values:
```html
{{#listfilter:
 | list       = a, b, c, d, e, f, g
 | indextoken = $
 | pattern    = <esc>{{#ifexpr: $ mod 2 > 0 | remove }}</esc>
}}
```

When using a template instead of a pattern, there is no easy way to get the value index from within the template.

## Proposed changes

Add an additional `{{{index}}}` parameter when transcluding templates (except for `#listmerge`), evaluating to the 1-based list value index (the same value as the one replacing `|indextoken=` in patterns).

Following the previous example, it means we could define a `Template:Remove even` template:
```
{{#ifexpr: {{{index}}} mod 2 > 0 | remove }}
```
then use it with `#listfilter`:
```
{{#listfilter:
 | list     = a, b, c, d, e, f, g
 | template = remove even
}}
```