### PR TITLE
Unescaping: Recognize `\s` escape sequences

### DIFF
--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -47,6 +47,7 @@ class ParserPower {
 	private const UNESCAPE_SEQS = [
 		'n' => "\n",
 		'_' => ' ',
+		's' => ' ',
 		'{' => '{',
 		'}' => '}',
 		'(' => '[',

--- a/tests/parser/simpleFunctionsTest.txt
+++ b/tests/parser/simpleFunctionsTest.txt
@@ -36,12 +36,12 @@ Target
 !! wikitext
 "<esc></esc>"
 "<esc>\
-{}[]<>=|</esc>" are all escaped
+  {}[]<>=|</esc>" are all escaped
 "<esc>\a\{\</esc>" only escapes backslashes
 "{{<esc>!</esc>}}" output is not stripped
 !! html/php
 <p>""
-"\\\n\{\}\(\)\l\g\e\!" are all escaped
+"\\\n\_\_\{\}\(\)\l\g\e\!" are all escaped
 "\\a\\{\\" only escapes backslashes
 "|" output is not stripped
 </p>
@@ -62,10 +62,13 @@ Target
 {{#uesc}}
 !! wikitext
 "{{#uesc:}}"
+"{{#uesc: \\\n\{\}\_\_\(\)\s\s\l\g\e\! }}"
 "{{#uesc: \_{\{!}\}\0 }}"
 "{{#uesc:\}}"
 !! html/php
 <p>""
+"\
+{}  []  &lt;&gt;=|"
 " |"
 "\"
 </p>


### PR DESCRIPTION
Proposal from @savagealien.

## Current state

ParserPower functions recognizes `\_` escape sequences for spaces:
- using `"<esc> a  b </esc>"` yields `"\_a\_\_b\_"`,
- using `"{{#uesc: \_a\_\_b\_ }}"` yields back `" a  b "`.

that can be used with list functions:
```html
{{#lstmap: a b  c | \_ | x | "x" | ,\_ }} <!-- yields "a", "b", "c" -->
```

Page Forms functions (`#arraymap` and ` #arraymaptemplate` that ParserPower also includes) recognize `\s` escape sequences for spaces:
```html
{{#arraymap: a b  c | \s | x | "x" | ,\s }} <!-- yields "a", "b", "c" -->
```

## Proposed changes

Make all list functions unescape `\s` as a space (the same way as `\_`), so the following alternatively works:
```html
{{#lstmap: a b  c | \s | x | "x" | ,\s }} <!-- yields "a", "b", "c" -->
```

`<esc>` behavior is unchanged, spaces are still replaced with `\_`.