### PR TITLE
refactor: Make `ParameterArranger` also manage numbered functions

### DIFF
--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -750,7 +750,7 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listfilterRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
+		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
@@ -982,7 +982,7 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listuniqueRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
+		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
@@ -1120,7 +1120,7 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listsortRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
+		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
@@ -1264,7 +1264,7 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listmapRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
+		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
@@ -1538,7 +1538,7 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function listmergeRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterArranger( $frame, $params, self::PARAM_OPTIONS );
+		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), self::PARAM_OPTIONS );
 
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -372,8 +372,8 @@ final class ListFunctions {
 	/**
 	 * Get an element from an array from its 1-based index.
 	 *
-	 * @param int $index 1-based index of the array element to get, or a negative value to start from the end.
 	 * @param array $values Array to get the element from.
+	 * @param int $index 1-based index of the array element to get, or a negative value to start from the end.
 	 * @return string The array element, or empty string if not found.
 	 */
 	private static function arrayElement( array $values, int $index ): string {
@@ -387,7 +387,8 @@ final class ListFunctions {
 
 	public function __construct(
 		private readonly bool $useLegacyLstmapExpansion
-	) { }
+	) {
+	}
 
 	/**
 	 * This function directs the counting operation for the lstcnt function.
@@ -404,7 +405,6 @@ final class ListFunctions {
 		] );
 
 		$list = $params->get( 0 );
-
 		if ( $list === '' ) {
 			return '0';
 		}
@@ -431,15 +431,13 @@ final class ListFunctions {
 		] );
 
 		$inList = $params->get( 0 );
-
 		if ( $inList === '' ) {
 			return '';
 		}
 
 		$inSep = $params->get( 1 );
-		$outSep = $params->get( 2 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
+		$outSep = $params->get( 2 );
 
 		$values = self::explodeList( $inSep, $inList );
 		return ParserPower::evaluateUnescaped( $parser, $frame, self::implodeList( $values, $outSep ) );
@@ -467,14 +465,9 @@ final class ListFunctions {
 		}
 
 		$inSep = $params->get( 1 );
-		$inIndex = $params->get( 2 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-
-		$index = 1;
-		if ( is_numeric( $inIndex ) ) {
-			$index = intval( $inIndex );
-		}
+		$index = $params->get( 2 );
+		$index = is_numeric( $index ) ? intval( $index ) : 1;
 
 		$value = self::arrayElement( self::explodeList( $inSep, $inList ), $index );
 
@@ -505,21 +498,12 @@ final class ListFunctions {
 		}
 
 		$inSep = $params->get( 1 );
-		$outSep = $params->get( 2 );
-		$inOffset = $params->get( 3 );
-		$inLength = $params->get( 4 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-
-		$offset = 0;
-		if ( is_numeric( $inOffset ) ) {
-			$offset = intval( $inOffset );
-		}
-
-		$length = null;
-		if ( is_numeric( $inLength ) ) {
-			$length = intval( $inLength );
-		}
+		$outSep = $params->get( 2 );
+		$offset = $params->get( 3 );
+		$offset = is_numeric( $offset ) ? intval( $offset ) : 0;
+		$length = $params->get( 4 );
+		$length = is_numeric( $length ) ? intval( $length ) : null;
 
 		$values = self::arraySlice( self::explodeList( $inSep, $inList ), $offset, $length );
 
@@ -554,9 +538,8 @@ final class ListFunctions {
 
 		$item = $params->get( 0 );
 		$sep = $params->get( 2 );
-		$csOption = $params->get( 3 );
-
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
+		$csOption = $params->get( 3 );
 		$csOption = self::decodeCSOption( $csOption );
 
 		$values = self::explodeList( $sep, $list );
@@ -600,10 +583,8 @@ final class ListFunctions {
 
 		$item = $params->get( 0 );
 		$sep = $params->get( 2 );
-		$inOptions = $params->get( 3 );
-
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
-		$options = self::decodeIndexOptions( $inOptions );
+		$options = self::decodeIndexOptions( $params->get( 3 ) );
 
 		$values = self::explodeList( $sep, $list );
 		$count = ( is_array( $values ) || $values instanceof Countable ) ? count( $values ) : 0;
@@ -662,7 +643,6 @@ final class ListFunctions {
 		}
 
 		$sep = $params->get( 1 );
-
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 
 		$values = self::explodeList( $sep, $list );
@@ -724,7 +704,6 @@ final class ListFunctions {
 
 		$inList1 = $params->get( 0 );
 		$inList2 = $params->get( 2 );
-
 		if ( $inList1 === '' && $inList2 === '' ) {
 			return '';
 		}
@@ -815,16 +794,18 @@ final class ListFunctions {
 
 		$keepValues = $params->get( 'keep' );
 		$keepSep = $params->get( 'keepsep' );
-		$keepCS = $params->get( 'keepcs' );
+		$keepCS = self::decodeBool( $params->get( 'keepcs' ) );
 		$removeValues = $params->get( 'remove' );
 		$removeSep = $params->get( 'removesep' );
-		$removeCS = $params->get( 'removecs' );
+		$removeCS = self::decodeBool( $params->get( 'removecs' ) );
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
 		$tokenSep = $params->get( 'tokensep' );
+		$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
 		$pattern = $params->get( 'pattern' );
 		$outSep = $params->get( 'outsep' );
 		$countToken = $params->get( 'counttoken' );
@@ -834,12 +815,6 @@ final class ListFunctions {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
-
-		$keepCS = self::decodeBool( $keepCS );
-		$removeCS = self::decodeBool( $removeCS );
-
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$tokenSep = $parser->getStripState()->unstripNoWiki( $tokenSep );
 
 		$inValues = self::explodeList( $inSep, $inList );
 
@@ -911,11 +886,9 @@ final class ListFunctions {
 		$values = $params->get( 0 );
 		$valueSep = $params->get( 1 );
 		$inSep = $params->get( 3 );
-		$outSep = $params->get( 4 );
-		$csOption = $params->get( 5 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$csOption = self::decodeCSOption( $csOption );
+		$outSep = $params->get( 4 );
+		$csOption = self::decodeCSOption( $params->get( 5 ) );
 
 		$inValues = self::explodeList( $inSep, $inList );
 
@@ -960,11 +933,9 @@ final class ListFunctions {
 
 		$value = $params->get( 0 );
 		$inSep = $params->get( 2 );
-		$outSep = $params->get( 3 );
-		$csOption = $params->get( 4 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$csOption = self::decodeCSOption( $csOption );
+		$outSep = $params->get( 3 );
+		$csOption = self::decodeCSOption( $params->get( 4 ) );
 
 		$inValues = self::explodeList( $inSep, $inList );
 
@@ -1009,16 +980,13 @@ final class ListFunctions {
 		] );
 
 		$inList = $params->get( 0 );
-
 		if ( $inList === '' ) {
 			return '0';
 		}
 
 		$sep = $params->get( 1 );
-		$csOption = $params->get( 2 );
-
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
-		$csOption = self::decodeCSOption( $csOption );
+		$csOption = self::decodeCSOption( $params->get( 2 ) );
 
 		$values = self::explodeList( $sep, $inList );
 		$values = self::reduceToUniqueValues( $values, $csOption );
@@ -1068,7 +1036,7 @@ final class ListFunctions {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 
-		$uniqueCS = $params->get( 'uniquecs' );
+		$uniqueCS = self::decodeBool( $params->get( 'uniquecs' ) );
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
 		$fieldSep = $params->get( 'fieldsep' );
@@ -1084,8 +1052,6 @@ final class ListFunctions {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
-
-		$uniqueCS = self::decodeBool( $uniqueCS );
 
 		$inValues = self::explodeList( $inSep, $inList );
 
@@ -1104,6 +1070,7 @@ final class ListFunctions {
 		} else {
 			$outValues = self::reduceToUniqueValues( $inValues, $uniqueCS );
 		}
+
 		$count = count( $outValues );
 		$outList = self::implodeList( $outValues, $outSep );
 		$outList = self::applyIntroAndOutro( $intro, $outList, $outro, $countToken, $count );
@@ -1133,11 +1100,9 @@ final class ListFunctions {
 		}
 
 		$inSep = $params->get( 1 );
-		$outSep = $params->get( 2 );
-		$csOption = $params->get( 3 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$csOption = self::decodeCSOption( $csOption );
+		$outSep = $params->get( 2 );
+		$csOption = self::decodeCSOption( $params->get( 3 ) );
 
 		$values = self::explodeList( $inSep, $inList );
 		$values = self::reduceToUniqueValues( $values, $csOption );
@@ -1215,6 +1180,7 @@ final class ListFunctions {
 
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
@@ -1222,9 +1188,9 @@ final class ListFunctions {
 		$pattern = $params->get( 'pattern' );
 		$outSep = $params->get( 'outsep' );
 		$sortOptions = $params->get( 'sortoptions' );
-		$subsort = $params->get( 'subsort' );
-		$subsortOptions = $params->get( 'subsortoptions' );
-		$duplicates = $params->get( 'duplicates' );
+		$subsort = self::decodeBool( $params->get( 'subsort' ) );
+		$subsortOptions = self::decodeSortOptions( $params->get( 'subsortoptions' ) );
+		$duplicates = self::decodeDuplicates( $params->get( 'duplicates' ) );
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
@@ -1233,16 +1199,9 @@ final class ListFunctions {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
 
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-
-		$subsort = self::decodeBool( $subsort );
-		if ( $subsort ) {
-			$subsortOptions = self::decodeSortOptions( $subsortOptions );
-		} else {
+		if ( !$subsort ) {
 			$subsortOptions = null;
 		}
-
-		$duplicates = self::decodeDuplicates( $duplicates );
 
 		$values = self::explodeList( $inSep, $inList );
 		if ( $duplicates & self::DUPLICATES_STRIP ) {
@@ -1309,11 +1268,10 @@ final class ListFunctions {
 		}
 
 		$inSep = $params->get( 1 );
-		$outSep = $params->get( 2 );
-		$sortOptions = $params->get( 3 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$sortOptions = self::decodeSortOptions( $sortOptions );
+		$outSep = $params->get( 2 );
+
+		$sortOptions = self::decodeSortOptions( $params->get( 3 ) );
 		$sorter = new ListSorter( $sortOptions );
 
 		$values = self::explodeList( $inSep, $inList );
@@ -1366,6 +1324,7 @@ final class ListFunctions {
 
 		$template = $params->get( 'template' );
 		$inSep = $params->get( 'insep' );
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$fieldSep = $params->get( 'fieldsep' );
 		$indexToken = $params->get( 'indextoken' );
 		$token = $params->get( 'token' );
@@ -1373,9 +1332,9 @@ final class ListFunctions {
 		$pattern = $params->get( 'pattern' );
 		$outSep = $params->get( 'outsep' );
 		$outConj = $params->get( 'outconj', [ 'default' => $outSep ] );
-		$sortMode = $params->get( 'sortmode' );
-		$sortOptions = $params->get( 'sortoptions' );
-		$duplicates = $params->get( 'duplicates' );
+		$sortMode = self::decodeSortMode( $params->get( 'sortmode' ) );
+		$sortOptions = self::decodeSortOptions( $params->get( 'sortoptions' ) );
+		$duplicates = self::decodeDuplicates( $params->get( 'duplicates' ) );
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
@@ -1383,11 +1342,6 @@ final class ListFunctions {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
-
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$sortMode = self::decodeSortMode( $sortMode );
-		$sortOptions = self::decodeSortOptions( $sortOptions );
-		$duplicates = self::decodeDuplicates( $duplicates );
 
 		$sorter = new ListSorter( $sortOptions );
 
@@ -1431,7 +1385,6 @@ final class ListFunctions {
 			$outValues = array_unique( $outValues );
 		}
 
-
 		$count = count( $outValues );
 		if ( $count === 0 ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
@@ -1473,15 +1426,12 @@ final class ListFunctions {
 		}
 
 		$inSep = $params->get( 1 );
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$token = $params->get( 2 );
 		$pattern = $params->get( 3 );
 		$outSep = $params->get( 4 );
-		$sortMode = $params->get( 5 );
-		$sortOptions = $params->get( 6 );
-
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$sortMode = self::decodeSortMode( $sortMode );
-		$sortOptions = self::decodeSortOptions( $sortOptions );
+		$sortMode = self::decodeSortMode( $params->get( 5 ) );
+		$sortOptions = self::decodeSortOptions( $params->get( 6 ) );
 
 		$sorter = new ListSorter( $sortOptions );
 
@@ -1531,13 +1481,10 @@ final class ListFunctions {
 
 		$template = $params->get( 1 );
 		$inSep = $params->get( 2 );
-		$outSep = $params->get( 3 );
-		$sortMode = $params->get( 4 );
-		$sortOptions = $params->get( 5 );
-
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$sortMode = self::decodeSortMode( $sortMode );
-		$sortOptions = self::decodeSortOptions( $sortOptions );
+		$outSep = $params->get( 3 );
+		$sortMode = self::decodeSortMode( $params->get( 4 ) );
+		$sortOptions = self::decodeSortOptions( $params->get( 5 ) );
 
 		$sorter = new ListSorter( $sortOptions );
 
@@ -1660,6 +1607,7 @@ final class ListFunctions {
 		$matchTemplate = $params->get( 'matchtemplate' );
 		$mergeTemplate = $params->get( 'mergetemplate' );
 		$inSep = $params->get( 'insep' );
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$fieldSep = $params->get( 'fieldsep' );
 		$token1 = $params->get( 'token1' );
 		$token2 = $params->get( 'token2' );
@@ -1667,8 +1615,8 @@ final class ListFunctions {
 		$matchPattern = $params->get( 'matchpattern' );
 		$mergePattern = $params->get( 'mergepattern' );
 		$outSep = $params->get( 'outsep' );
-		$sortMode = $params->get( 'sortmode' );
-		$sortOptions = $params->get( 'sortoptions' );
+		$sortMode = self::decodeSortMode( $params->get( 'sortmode' ) );
+		$sortOptions = self::decodeSortOptions( $params->get( 'sortoptions' ) );
 		$countToken = $params->get( 'counttoken' );
 		$intro = $params->get( 'intro' );
 		$outro = $params->get( 'outro' );
@@ -1676,10 +1624,6 @@ final class ListFunctions {
 		if ( $inList === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
 		}
-
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$sortMode = self::decodeSortMode( $sortMode );
-		$sortOptions = self::decodeSortOptions( $sortOptions );
 
 		$sorter = new ListSorter( $sortOptions );
 

--- a/src/ListFunctions.php
+++ b/src/ListFunctions.php
@@ -398,14 +398,18 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstcntRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$list = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep']
+		] );
+
+		$list = $params->get( 0 );
 
 		if ( $list === '' ) {
 			return '0';
 		}
 
-		$sep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-
+		$sep = $params->get( 1 );
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 
 		return (string)count( self::explodeList( $sep, $list ) );
@@ -420,14 +424,20 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstsepRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep']
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[2] ?? ',\_', ParserPower::UNESCAPE );
+		$inSep = $params->get( 1 );
+		$outSep = $params->get( 2 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
@@ -444,14 +454,20 @@ final class ListFunctions {
 	 * @return string The function output along with relevant parser options.
 	 */
 	public function lstelemRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			[ 'unescape' => true ]
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$inIndex = ParserPower::expand( $frame, $params[2] ?? '', ParserPower::UNESCAPE );
+		$inSep = $params->get( 1 );
+		$inIndex = $params->get( 2 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
@@ -474,16 +490,24 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstsubRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep'],
+			[ 'unescape' => true ],
+			[ 'unescape' => true ]
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[2] ?? ',\_', ParserPower::UNESCAPE );
-		$inOffset = ParserPower::expand( $frame, $params[3] ?? '', ParserPower::UNESCAPE );
-		$inLength = ParserPower::expand( $frame, $params[4] ?? '', ParserPower::UNESCAPE );
+		$inSep = $params->get( 1 );
+		$outSep = $params->get( 2 );
+		$inOffset = $params->get( 3 );
+		$inLength = $params->get( 4 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 
@@ -515,15 +539,22 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstfndRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$list = ParserPower::expand( $frame, $params[1] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			[ 'unescape' => true ],
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			[]
+		] );
+
+		$list = $params->get( 1 );
 
 		if ( $list === '' ) {
 			return '';
 		}
 
-		$item = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
-		$sep = ParserPower::expand( $frame, $params[2] ?? ',', ParserPower::UNESCAPE );
-		$csOption = ParserPower::expand( $frame, $params[3] ?? '' );
+		$item = $params->get( 0 );
+		$sep = $params->get( 2 );
+		$csOption = $params->get( 3 );
 
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$csOption = self::decodeCSOption( $csOption );
@@ -554,15 +585,22 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstindRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$list = ParserPower::expand( $frame, $params[1] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			[ 'unescape' => true ],
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			[]
+		] );
+
+		$list = $params->get( 1 );
 
 		if ( $list === '' ) {
 			return '';
 		}
 
-		$item = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
-		$sep = ParserPower::expand( $frame, $params[2] ?? ',', ParserPower::UNESCAPE );
-		$inOptions = ParserPower::expand( $frame, $params[3] ?? '' );
+		$item = $params->get( 0 );
+		$sep = $params->get( 2 );
+		$inOptions = $params->get( 3 );
 
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$options = self::decodeIndexOptions( $inOptions );
@@ -610,14 +648,20 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstappRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$list = ParserPower::expand( $frame, $params[0] ?? '' );
-		$value = ParserPower::expand( $frame, $params[2] ?? '', ParserPower::UNESCAPE );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			[ 'unescape' => true ]
+		] );
+
+		$list = $params->get( 0 );
+		$value = $params->get( 2 );
 
 		if ( $list === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $value );
 		}
 
-		$sep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
+		$sep = $params->get( 1 );
 
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 
@@ -637,14 +681,20 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstprepRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$value = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
-		$list = ParserPower::expand( $frame, $params[2] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			[ 'unescape' => true ],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['list']
+		] );
+
+		$value = $params->get( 0 );
+		$list = $params->get( 2 );
 
 		if ( $list === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $value );
 		}
 
-		$sep = ParserPower::expand( $frame, $params[1] ?? '', ParserPower::UNESCAPE );
+		$sep = $params->get( 1 );
 
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 
@@ -664,8 +714,16 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstjoinRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList1 = ParserPower::expand( $frame, $params[0] ?? '' );
-		$inList2 = ParserPower::expand( $frame, $params[2] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep']
+		] );
+
+		$inList1 = $params->get( 0 );
+		$inList2 = $params->get( 2 );
 
 		if ( $inList1 === '' && $inList2 === '' ) {
 			return '';
@@ -674,7 +732,7 @@ final class ListFunctions {
 		if ( $inList1 === '' ) {
 			$values1 = [];
 		} else {
-			$inSep1 = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
+			$inSep1 = $params->get( 1 );
 			$inSep1 = $parser->getStripState()->unstripNoWiki( $inSep1 );
 			$values1 = self::explodeList( $inSep1, $inList1 );
 		}
@@ -682,12 +740,12 @@ final class ListFunctions {
 		if ( $inList2 === '' ) {
 			$values2 = [];
 		} else {
-			$inSep2 = ParserPower::expand( $frame, $params[3] ?? ',', ParserPower::UNESCAPE );
+			$inSep2 = $params->get( 3 );
 			$inSep2 = $parser->getStripState()->unstripNoWiki( $inSep2 );
 			$values2 = self::explodeList( $inSep2, $inList2 );
 		}
 
-		$outSep = ParserPower::expand( $frame, $params[4] ?? ',\_', ParserPower::UNESCAPE );
+		$outSep = $params->get( 4 );
 
 		$values = array_merge( $values1, $values2 );
 		return ParserPower::evaluateUnescaped( $parser, $frame, self::implodeList( $values, $outSep ) );
@@ -835,17 +893,26 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstfltrRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[2] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['keep'],
+			self::PARAM_OPTIONS['keepsep'],
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep'],
+			[]
+		] );
+
+		$inList = $params->get( 2 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$values = ParserPower::expand( $frame, $params[0] ?? '' );
-		$valueSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$inSep = ParserPower::expand( $frame, $params[3] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[4] ?? ',\_', ParserPower::UNESCAPE );
-		$csOption = ParserPower::expand( $frame, $params[5] ?? '' );
+		$values = $params->get( 0 );
+		$valueSep = $params->get( 1 );
+		$inSep = $params->get( 3 );
+		$outSep = $params->get( 4 );
+		$csOption = $params->get( 5 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$csOption = self::decodeCSOption( $csOption );
@@ -877,16 +944,24 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstrmRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[1] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			[ 'unescape' => true ],
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep'],
+			[]
+		] );
+
+		$inList = $params->get( 1 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$value = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
-		$inSep = ParserPower::expand( $frame, $params[2] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[3] ?? ',\_', ParserPower::UNESCAPE );
-		$csOption = ParserPower::expand( $frame, $params[4] ?? '' );
+		$value = $params->get( 0 );
+		$inSep = $params->get( 2 );
+		$outSep = $params->get( 3 );
+		$csOption = $params->get( 4 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$csOption = self::decodeCSOption( $csOption );
@@ -927,14 +1002,20 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstcntuniqRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			[]
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '0';
 		}
 
-		$sep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$csOption = ParserPower::expand( $frame, $params[2] ?? '' );
+		$sep = $params->get( 1 );
+		$csOption = $params->get( 2 );
 
 		$sep = $parser->getStripState()->unstripNoWiki( $sep );
 		$csOption = self::decodeCSOption( $csOption );
@@ -1038,15 +1119,22 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstuniqRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep'],
+			[]
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[2] ?? ',\_', ParserPower::UNESCAPE );
-		$csOption = ParserPower::expand( $frame, $params[3] ?? '' );
+		$inSep = $params->get( 1 );
+		$outSep = $params->get( 2 );
+		$csOption = $params->get( 3 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$csOption = self::decodeCSOption( $csOption );
@@ -1207,15 +1295,22 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstsrtRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep'],
+			self::PARAM_OPTIONS['sortoptions']
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[2] ?? ',\_', ParserPower::UNESCAPE );
-		$sortOptions = ParserPower::expand( $frame, $params[3] ?? '' );
+		$inSep = $params->get( 1 );
+		$outSep = $params->get( 2 );
+		$sortOptions = $params->get( 3 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$sortOptions = self::decodeSortOptions( $sortOptions );
@@ -1360,19 +1455,29 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstmapRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$legacyExpansionFlags = $this->useLegacyLstmapExpansion ? [ 'novars' => true ] : [];
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['insep'],
+			array_merge( self::PARAM_OPTIONS['token'], [ 'default' => 'x' ], $legacyExpansionFlags ),
+			array_merge( self::PARAM_OPTIONS['pattern'], [ 'default' => 'x' ], $legacyExpansionFlags ),
+			self::PARAM_OPTIONS['outsep'],
+			[],
+			self::PARAM_OPTIONS['sortoptions']
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$inSep = ParserPower::expand( $frame, $params[1] ?? ',', ParserPower::UNESCAPE );
-		$legacyExpansionFlags = $this->useLegacyLstmapExpansion ? ParserPower::NO_VARS : 0;
-		$token = ParserPower::expand( $frame, $params[2] ?? 'x', $legacyExpansionFlags | ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params[3] ?? 'x', $legacyExpansionFlags );
-		$outSep = ParserPower::expand( $frame, $params[4] ?? ',\_', ParserPower::UNESCAPE );
-		$sortMode = ParserPower::expand( $frame, $params[5] ?? '' );
-		$sortOptions = ParserPower::expand( $frame, $params[6] ?? '' );
+		$inSep = $params->get( 1 );
+		$token = $params->get( 2 );
+		$pattern = $params->get( 3 );
+		$outSep = $params->get( 4 );
+		$sortMode = $params->get( 5 );
+		$sortOptions = $params->get( 6 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$sortMode = self::decodeSortMode( $sortMode );
@@ -1409,17 +1514,26 @@ final class ListFunctions {
 	 * @return string The function output.
 	 */
 	public function lstmaptempRender( Parser $parser, PPFrame $frame, array $params ): string {
-		$inList = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			self::PARAM_OPTIONS['list'],
+			self::PARAM_OPTIONS['template'],
+			self::PARAM_OPTIONS['insep'],
+			self::PARAM_OPTIONS['outsep'],
+			[],
+			self::PARAM_OPTIONS['sortoptions']
+		] );
+
+		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {
 			return '';
 		}
 
-		$template = ParserPower::expand( $frame, $params[1] ?? '' );
-		$inSep = ParserPower::expand( $frame, $params[2] ?? ',', ParserPower::UNESCAPE );
-		$outSep = ParserPower::expand( $frame, $params[3] ?? ',\_', ParserPower::UNESCAPE );
-		$sortMode = ParserPower::expand( $frame, $params[4] ?? '' );
-		$sortOptions = ParserPower::expand( $frame, $params[5] ?? '' );
+		$template = $params->get( 1 );
+		$inSep = $params->get( 2 );
+		$outSep = $params->get( 3 );
+		$sortMode = $params->get( 4 );
+		$sortOptions = $params->get( 5 );
 
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$sortMode = self::decodeSortMode( $sortMode );

--- a/src/ParameterArranger.php
+++ b/src/ParameterArranger.php
@@ -33,25 +33,26 @@ final class ParameterArranger {
 		private array $paramOptions = []
 	) {
 		$this->params = [];
-
-		if ( isset( $params[0] ) && is_string( $params[0] ) ) {
-			$pair = explode( '=', array_shift( $params ), 2 );
-			if ( count( $pair ) === 2 ) {
-				$key = ParserPower::expand( $this->frame, $pair[0] );
-				$this->params[$key] = $pair[1];
-			} else {
-				$this->params[] = $pair[0];
-			}
-		}
+		$numberedCount = 0;
 
 		foreach ( $params as $param ) {
-			$bits = $param->splitArg();
-			if ( $bits['index'] === '' ) {
-				$key = ParserPower::expand( $this->frame, $bits['name'] );
-				$this->params[$key] = $bits['value'];
+			if ( is_string( $param ) ) {
+				$pair = explode( '=', $param, 2 );
+				if ( isset( $pair[1] ) ) {
+					$key = array_shift( $pair );
+				}
+				$value = $pair[0];
 			} else {
-				$this->params[] = $bits['value'];
+				$bits = $param->splitArg();
+				if ( $bits['index'] === '' ) {
+					$key = $bits['name'];
+				}
+				$value = $bits['value'];
 			}
+
+			$key = isset( $key ) ? ParserPower::expand( $frame, $key ) : $numberedCount++;
+
+			$this->params[$key] = $value;
 		}
 	}
 

--- a/src/ParameterArranger.php
+++ b/src/ParameterArranger.php
@@ -24,7 +24,7 @@ final class ParameterArranger {
 
 	/**
 	 * @param PPFrame $frame Parser frame object.
-	 * @param array $params Parameters and values together, not yet expanded or trimmed.
+	 * @param array $params Unexpanded parameters.
 	 * @param array $paramOptions Parsing and post-processing options for all parameters.
 	 */
 	public function __construct(
@@ -32,28 +32,7 @@ final class ParameterArranger {
 		array $params,
 		private array $paramOptions = []
 	) {
-		$this->params = [];
-		$numberedCount = 0;
-
-		foreach ( $params as $param ) {
-			if ( is_string( $param ) ) {
-				$pair = explode( '=', $param, 2 );
-				if ( isset( $pair[1] ) ) {
-					$key = array_shift( $pair );
-				}
-				$value = $pair[0];
-			} else {
-				$bits = $param->splitArg();
-				if ( $bits['index'] === '' ) {
-					$key = $bits['name'];
-				}
-				$value = $bits['value'];
-			}
-
-			$key = isset( $key ) ? ParserPower::expand( $frame, $key ) : $numberedCount++;
-
-			$this->params[$key] = $value;
-		}
+		$this->params = self::arrange( $frame, $params );
 	}
 
 	/**
@@ -83,5 +62,38 @@ final class ParameterArranger {
 
 		$this->expandedParams[$key] = $value;
 		return $value;
+	}
+
+	/**
+	 * Arranges parser function parameters, separating named from numbered parameters.
+	 *
+	 * @param PPFrame $frame Parser frame object.
+	 * @param array $params Unexpanded parameters.
+	 */
+	public static function arrange( PPFrame $frame, array $params ): array {
+		$arrangedParams = [];
+		$numberedCount = 0;
+
+		foreach ( $params as $param ) {
+			if ( is_string( $param ) ) {
+				$pair = explode( '=', $param, 2 );
+				if ( isset( $pair[1] ) ) {
+					$key = array_shift( $pair );
+				}
+				$value = $pair[0];
+			} else {
+				$bits = $param->splitArg();
+				if ( $bits['index'] === '' ) {
+					$key = $bits['name'];
+				}
+				$value = $bits['value'];
+			}
+
+			$key = isset( $key ) ? ParserPower::expand( $frame, $key ) : $numberedCount++;
+
+			$arrangedParams[$key] = $value;
+		}
+
+		return $arrangedParams;
 	}
 }

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -14,7 +14,7 @@ use MediaWiki\Parser\PPFrame;
 final class ParameterParser {
 
 	/**
-	 * Expanded (and post-processed) parameters.
+	 * @var array Expanded (and post-processed) parameters.
 	 */
 	private array $expandedParams = [];
 
@@ -67,6 +67,7 @@ final class ParameterParser {
 	 *
 	 * @param PPFrame $frame Parser frame object.
 	 * @param array $params Unexpanded parameters.
+	 * @return array Parameters with separated keys and values.
 	 */
 	public static function arrange( PPFrame $frame, array $params ): array {
 		$arrangedParams = [];

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -51,6 +51,9 @@ final class ParameterParser {
 			if ( $options['unescape'] ?? false ) {
 				$flags |= ParserPower::UNESCAPE;
 			}
+			if ( $options['novars'] ?? false ) {
+				$flags |= ParserPower::NO_VARS;
+			}
 
 			$value = ParserPower::expand( $this->frame, $this->params[$key], $flags );
 		}

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -7,16 +7,12 @@ namespace MediaWiki\Extension\ParserPower;
 use MediaWiki\Parser\PPFrame;
 
 /**
- * Named parameter arranger for parser functions.
- * Only evaluates parameter valuyes on use site, and applies some post-processings to parsed values,
+ * Parameter parser for parser functions.
+ * Only evaluates parameter values on use site, and applies some post-processing steps to parsed values,
  * such as trimming whitespaces (as per longstanding MediaWiki conventions).
  */
-final class ParameterArranger {
+final class ParameterParser {
 
-	/**
-	 * Unexpanded parameters.
-	 */
-	private array $params;
 	/**
 	 * Expanded (and post-processed) parameters.
 	 */
@@ -29,10 +25,9 @@ final class ParameterArranger {
 	 */
 	public function __construct(
 		private readonly PPFrame $frame,
-		array $params,
+		private array $params,
 		private array $paramOptions = []
 	) {
-		$this->params = self::arrange( $frame, $params );
 	}
 
 	/**


### PR DESCRIPTION
This PR follows #32, in which parameter processing for list functions was delegated to a `ParameterArranger` object.

This PR intends to slightly extend `ParameterArranger` to make it manage functions that accept numbered parameters. In practice, rename `ParameterArranger` to `ParameterParser` and split parameter keys from values by default, instead in a separate `ParameterParser::arrange` function.

This would allow us to apply the same pre-processing steps to parameters from named and numbered functions without duplicating more stuff, and allow us to define functions with both numbered and named arguments more easily.