### PR TITLE
refactor: Use `ParameterParser` with non-list functions

### DIFF
--- a/src/Function/FollowFunction.php
+++ b/src/Function/FollowFunction.php
@@ -4,7 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
-use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Page\RedirectLookup;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -34,7 +34,11 @@ final class FollowFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$text = trim( ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE ) );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [ 'unescape' => true ]
+		] );
+
+		$text = trim( $params->get( 0 ) );
 
 		$title = Title::newFromText( $text );
 		if ( $title === null || $title->getNamespace() === NS_MEDIA || $title->getNamespace() < 0 ) {

--- a/src/Function/LinkPageFunction.php
+++ b/src/Function/LinkPageFunction.php
@@ -4,7 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
-use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -35,8 +35,11 @@ final class LinkPageFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$text = ParserPower::expand( $frame, $params[0] ?? '' );
-		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'replace' ], $text );
+		$params = new ParameterParser( $frame, $params, [
+			0 => []
+		] );
+
+		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'replace' ], $params->get( 0 ) );
 	}
 
 	/**

--- a/src/Function/LinkTextFunction.php
+++ b/src/Function/LinkTextFunction.php
@@ -4,7 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
-use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -39,8 +39,11 @@ final class LinkTextFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$text = ParserPower::expand( $frame, $params[0] ?? '' );
-		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'replace' ], $text );
+		$params = new ParameterParser( $frame, $params, [
+			0 => []
+		] );
+
+		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'replace' ], $params->get( 0 ) );
 	}
 
 	/**

--- a/src/Function/OrFunction.php
+++ b/src/Function/OrFunction.php
@@ -4,7 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
-use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -24,8 +24,10 @@ final class OrFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		foreach ( $params as $param ) {
-			$inValue = ParserPower::expand( $frame, $param );
+		$params = new ParameterParser( $frame, $params );
+
+		for ( $i = 0; $params->isDefined( $i ); ++$i ) {
+			$inValue = $params->get( $i );
 
 			if ( $inValue !== '' ) {
 				return $inValue;

--- a/src/Function/TokenFunction.php
+++ b/src/Function/TokenFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -24,12 +25,13 @@ final class TokenFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$inValue = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [],
+			1 => [ 'default' => 'x', 'unescape' => true ],
+			2 => [ 'default' => 'x', 'novars' => true ]
+		] );
 
-		$token = ParserPower::expand( $frame, $params[1] ?? 'x', ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params[2] ?? 'x', ParserPower::NO_VARS );
-
-		$outValue = ParserPower::applyPattern( $inValue, $token, $pattern );
+		$outValue = ParserPower::applyPattern( $params->get( 0 ), $params->get( 1 ), $params->get( 2 ) );
 		$outValue = $parser->preprocessToDom( $outValue, $frame->isTemplate() ? Parser::PTD_FOR_INCLUSION : 0 );
 		$outValue = ParserPower::expand( $frame, $outValue, ParserPower::UNESCAPE );
 

--- a/src/Function/TokenIfFunction.php
+++ b/src/Function/TokenIfFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -24,17 +25,19 @@ final class TokenIfFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$inValue = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [],
+			1 => [ 'default' => 'x', 'unescape' => true ],
+			2 => [ 'default' => 'x', 'novars' => true ],
+			3 => [ 'unescape' => true ]
+		] );
 
+		$inValue = $params->get( 0 );
 		if ( $inValue === '' ) {
-			$default = ParserPower::expand( $frame, $params[3] ?? '', ParserPower::UNESCAPE );
-			return ParserPower::evaluateUnescaped( $parser, $frame, $default );
+			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 3 ) );
 		}
 
-		$token = ParserPower::expand( $frame, $params[1] ?? 'x', ParserPower::UNESCAPE );
-		$pattern = ParserPower::expand( $frame, $params[2] ?? 'x', ParserPower::NO_VARS );
-
-		$outValue = ParserPower::applyPattern( $inValue, $token, $pattern );
+		$outValue = ParserPower::applyPattern( $inValue, $params->get( 1 ), $params->get( 2 ) );
 		$outValue = $parser->preprocessToDom( $outValue, $frame->isTemplate() ? Parser::PTD_FOR_INCLUSION : 0 );
 		$outValue = ParserPower::expand( $frame, $outValue, ParserPower::UNESCAPE );
 

--- a/src/Function/TrimFunction.php
+++ b/src/Function/TrimFunction.php
@@ -4,7 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
-use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -24,6 +24,10 @@ final class TrimFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		return ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			0 => []
+		] );
+
+		return $params->get( 0 );
 	}
 }

--- a/src/Function/TrimUescFunction.php
+++ b/src/Function/TrimUescFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -25,7 +26,11 @@ final class TrimUescFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$text = trim( ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE ) );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [ 'unescape' => true ]
+		] );
+
+		$text = trim( $params->get( 0 ) );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $text );
 	}

--- a/src/Function/UeIfFunction.php
+++ b/src/Function/UeIfFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -24,12 +25,16 @@ final class UeIfFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$condition = ParserPower::expand( $frame, $params[0] ?? '' );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [],
+			1 => [ 'unescape' => true ],
+			2 => [ 'unescape' => true ]
+		] );
 
-		if ( $condition !== '' ) {
-			$value = ParserPower::expand( $frame, $params[1] ?? '', ParserPower::UNESCAPE );
+		if ( $params->get( 0 ) !== '' ) {
+			$value = $params->get( 1 );
 		} else {
-			$value = ParserPower::expand( $frame, $params[2] ?? '', ParserPower::UNESCAPE );
+			$value = $params->get( 2 );
 		}
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $value );

--- a/src/Function/UeIfeqFunction.php
+++ b/src/Function/UeIfeqFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -24,13 +25,17 @@ final class UeIfeqFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$leftValue = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
-		$rightValue = ParserPower::expand( $frame, $params[1] ?? '', ParserPower::UNESCAPE );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [ 'unescape' => true ],
+			1 => [ 'unescape' => true ],
+			2 => [ 'unescape' => true ],
+			3 => [ 'unescape' => true ]
+		] );
 
-		if ( $leftValue === $rightValue ) {
-			$value = ParserPower::expand( $frame, $params[2] ?? '', ParserPower::UNESCAPE );
+		if ( $params->get( 0 ) === $params->get( 1 ) ) {
+			$value = $params->get( 2 );
 		} else {
-			$value = ParserPower::expand( $frame, $params[3] ?? '', ParserPower::UNESCAPE );
+			$value = $params->get( 3 );
 		}
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $value );

--- a/src/Function/UeOrFunction.php
+++ b/src/Function/UeOrFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -24,8 +25,10 @@ final class UeOrFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		foreach ( $params as $param ) {
-			$inValue = ParserPower::expand( $frame, $param );
+		$params = new ParameterParser( $frame, $params );
+
+		for ( $i = 0; $params->isDefined( $i ); ++$i ) {
+			$inValue = $params->get( $i );
 
 			if ( $inValue !== '' ) {
 				$inValue = ParserPower::unescape( $inValue );

--- a/src/Function/UescFunction.php
+++ b/src/Function/UescFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -24,8 +25,10 @@ final class UescFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$text = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [ 'unescape' => true ]
+		] );
 
-		return ParserPower::evaluateUnescaped( $parser, $frame, $text );
+		return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 0 ) );
 	}
 }

--- a/src/Function/UescNowikiFunction.php
+++ b/src/Function/UescNowikiFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
@@ -25,8 +26,10 @@ final class UescNowikiFunction implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$text = ParserPower::expand( $frame, $params[0] ?? '', ParserPower::UNESCAPE );
+		$params = new ParameterParser( $frame, $params, [
+			0 => [ 'unescape' => true ]
+		] );
 
-		return ParserPower::evaluateUnescaped( $parser, $frame, '<nowiki>' . $text . '</nowiki>' );
+		return ParserPower::evaluateUnescaped( $parser, $frame, '<nowiki>' . $params->get( 0 ) . '</nowiki>' );
 	}
 }

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -22,11 +22,13 @@ final class ParameterParser {
 	 * @param PPFrame $frame Parser frame object.
 	 * @param array $params Unexpanded parameters.
 	 * @param array $paramOptions Parsing and post-processing options for all parameters.
+	 * @param array $defaultOptions Parsing and post-processing options for unknown parameters.
 	 */
 	public function __construct(
 		private readonly PPFrame $frame,
 		private array $params,
-		private array $paramOptions = []
+		private array $paramOptions = [],
+		private array $defaultOptions = []
 	) {
 	}
 
@@ -42,7 +44,7 @@ final class ParameterParser {
 			return $this->expandedParams[$key];
 		}
 
-		$options = array_merge( $this->paramOptions[$key] ?? [], $options );
+		$options = array_merge( $this->paramOptions[$key] ?? $this->defaultOptions, $options );
 
 		if ( !isset( $this->params[$key] ) ) {
 			$value = $options['default'] ?? '';

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -33,6 +33,16 @@ final class ParameterParser {
 	}
 
 	/**
+	 * Check whether a parameter is defined, without evaluating it.
+	 *
+	 * @param int|string $key Parameter index or name.
+	 * @return bool True if the parameter is defined, false otherwise.
+	 */
+	public function isDefined( int|string $key ): bool {
+		return isset( $this->params[$key] );
+	}
+
+	/**
 	 * Get the expanded value of a parameter.
 	 *
 	 * @param int|string $key Parameter index or name.


### PR DESCRIPTION
With #32 and #39, all list functions (without exception) now use a `ParameterParser` object to evaluate their arguments lazily, without having to duplicate their evaluation specification.

## Proposed changes

This PR makes non-list functions also use a `ParameterParser` to manage their parameters. For this purpose, `ParameterParser` behavior is slightly extended:
- provide a `$params->isDefined( $k )` method to replace an `isset( $params[$k] )` parameter array check, and
- allow to define evaluation options for unknown parameters, so it can manage functions that allow an arbitrary number of parameters (`#or` and `#ueor`).