### PR TITLE
Add test cases for `#argmap`/`#iargmap`/`#arraymap`/`#arraymaptemplate`

### DIFF
--- a/tests/parser/simpleFunctionsTest.txt
+++ b/tests/parser/simpleFunctionsTest.txt
@@ -25,6 +25,18 @@ Target
 1
 !! endarticle
 
+!! article
+Template:Uesc
+!! text
+{{#uesc: {{{v|{{{1}}}}}} }}
+!! endarticle
+
+!! article
+Template:Argmap
+!! text
+{{{x}}}!{{{x|}}}!{{{y}}}!{{{y|}}}
+!! endarticle
+
 # NOTE: we use the following strings (concatenated) as parameter values below for testing some unescaping behaviors:
 #  - wikitext is not unescaped:          "\0"      -> "\0"
 #  - wikitext is unescaped only once:    "\\0"     -> "\0"
@@ -298,5 +310,112 @@ Target#X Target Target#Section
 " |\0\y\y"
 " |\0z"
 " |\0\y\y"
+</p>
+!! end
+
+!! test
+{{#argmap}} args
+!! wikitext
+"{{uesc | <esc>{{#argmap: }}</esc> }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | x1 = }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x1 = }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | x1 = a }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x1 = a }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | y1 = }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | y1 = }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | y1 = a }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | y1 = a }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | x1 = a | y1 = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x1 = a | y1 = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | y1 = a | x1 = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | y1 = a | x1 = b }}"
+!! html/php
+<p>"" ""
+"{{|x=}}" "!!{{{y}}}!"
+"{{|x=a}}" "a!a!{{{y}}}!"
+"{{|y=}}" "{{{x}}}!!!"
+"{{|y=a}}" "{{{x}}}!!a!a"
+"{{|x=a|y=b}}" "a!a!b!b"
+"{{|y=a|x=b}}" "b!b!a!a"
+</p>
+!! end
+
+!! test
+{{#argmap}} position
+!! wikitext
+"{{uesc | <esc>{{#argmap: }}</esc> | x = a | x = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x = a | x = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | x1 = a | x2 = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x1 = a | x2 = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | x1 = a | 2x = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x1 = a | 2x = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | 1x = a | 2x = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | 1x = a | 2x = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | x2 = a | x1 = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | x2 = a | x1 = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | 2x = a | x1 = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | 2x = a | x1 = b }}"
+"{{uesc | <esc>{{#argmap: }}</esc> | 2x = a | 1x = b }}" "{{uesc | <esc>{{#argmap: argmap }}</esc> | 2x = a | 1x = b }}"
+!! html/php
+<p>"" ""
+"{{|x=a}}, {{|x=b}}" "a!a!{{{y}}}!, b!b!{{{y}}}!"
+"{{|x=a}}, {{|x=b}}" "a!a!{{{y}}}!, b!b!{{{y}}}!"
+"{{|x=a}}, {{|x=b}}" "a!a!{{{y}}}!, b!b!{{{y}}}!"
+"{{|x=a}}, {{|x=b}}" "a!a!{{{y}}}!, b!b!{{{y}}}!"
+"{{|x=a}}, {{|x=b}}" "a!a!{{{y}}}!, b!b!{{{y}}}!"
+"{{|x=a}}, {{|x=b}}" "a!a!{{{y}}}!, b!b!{{{y}}}!"
+</p>
+!! end
+
+!! test
+{{#argmap}} numbering
+!! wikitext
+"{{uesc | <esc>{{#argmap: }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+!! html/php
+<p>"{{|x=0}}, {{|x=1}}, {{|x=2}}, {{|x=1000}}"
+"0!0!{{{y}}}!, 1!1!{{{y}}}!, 2!2!{{{y}}}!, 1000!1000!{{{y}}}!"
+</p>
+!! end
+
+!! test
+{{#argmap}} glue
+!! wikitext
+"{{uesc | <esc>{{#argmap: argmap | }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | ,\n }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+!! html/php
+<p>"0!0!{{{y}}}!1!1!{{{y}}}!2!2!{{{y}}}!1000!1000!{{{y}}}!"
+"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+"0!0!{{{y}}}!,
+1!1!{{{y}}}!,
+2!2!{{{y}}}!,
+1000!1000!{{{y}}}!"
+</p>
+!! end
+
+!! test
+{{#argmap}} mustcontain
+!! wikitext
+"{{uesc | <esc>{{#argmap: argmap | , | }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | x }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | x, }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | y }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | y, }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | x,y }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+!! html/php
+<p>"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+""
+""
+""
+""
+</p>
+!! end
+
+!! test
+{{#argmap}} onlyshow
+!! wikitext
+"{{uesc | <esc>{{#argmap: argmap | , | | }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | | x }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | | x, }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | | y }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | | y, }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+"{{uesc | <esc>{{#argmap: argmap | , | | x,y }}</esc> | x0 = 0 | x1 = 1 | x2 = 2 | x1000 = 1000 }}"
+!! html/php
+<p>"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+""
+""
+"0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
 </p>
 !! end

--- a/tests/parser/simpleFunctionsTest.txt
+++ b/tests/parser/simpleFunctionsTest.txt
@@ -37,6 +37,12 @@ Template:Argmap
 {{{x}}}!{{{x|}}}!{{{y}}}!{{{y|}}}
 !! endarticle
 
+!! article
+Template:Iargmap
+!! text
+{{{1}}}!{{{1|}}}!{{{2}}}!{{{2|}}}
+!! endarticle
+
 # NOTE: we use the following strings (concatenated) as parameter values below for testing some unescaping behaviors:
 #  - wikitext is not unescaped:          "\0"      -> "\0"
 #  - wikitext is unescaped only once:    "\\0"     -> "\0"
@@ -417,5 +423,44 @@ Target#X Target Target#Section
 ""
 ""
 "0!0!{{{y}}}!,1!1!{{{y}}}!,2!2!{{{y}}}!,1000!1000!{{{y}}}!"
+</p>
+!! end
+
+!! test
+{{#iargmap}} args
+!! wikitext
+"{{uesc | v = <esc>{{#iargmap: }}</esc> }}" "{{uesc | v = <esc>{{#iargmap: iargmap }}</esc> }}"
+"{{uesc | v = <esc>{{#iargmap: | }}</esc> }}" "{{uesc | v = <esc>{{#iargmap: iargmap | }}</esc> }}"
+"{{uesc | v = <esc>{{#iargmap: | }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: | 1x }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | 1x }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: | 1 }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | 1 }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: | 2 }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | 2 }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: | 3 }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | 3 }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: | 4 }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | 4 }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: | 5 }}</esc> | a | b | c | d }}" "{{uesc | v = <esc>{{#iargmap: iargmap | 5 }}</esc> | a | b | c | d }}"
+!! html/php
+<p>"<strong class="error">iargmap error: The parameter "n" is required.</strong>" "<strong class="error">iargmap error: The parameter "n" is required.</strong>"
+"<strong class="error">iargmap error: No formatter arguments were given.</strong>" "<strong class="error">iargmap error: No formatter arguments were given.</strong>"
+"<strong class="error">iargmap error: "n" must be an integer.</strong>" "<strong class="error">iargmap error: "n" must be an integer.</strong>"
+"<strong class="error">iargmap error: "n" must be an integer.</strong>" "<strong class="error">iargmap error: "n" must be an integer.</strong>"
+"{{|a}}, {{|b}}, {{|c}}, {{|d}}" "a!a!{{{2}}}!, b!b!{{{2}}}!, c!c!{{{2}}}!, d!d!{{{2}}}!"
+"{{|a|b}}, {{|c|d}}" "a!a!b!b, c!c!d!d"
+"<strong class="error">iargmap error: The number of given formatter arguments must be divisible by "n".</strong>" "<strong class="error">iargmap error: The number of given formatter arguments must be divisible by "n".</strong>"
+"{{|a|b|c|d}}" "a!a!b!b"
+"<strong class="error">iargmap error: The number of given formatter arguments must be divisible by "n".</strong>" "<strong class="error">iargmap error: The number of given formatter arguments must be divisible by "n".</strong>"
+</p>
+!! end
+
+!! test
+{{#iargmap}} glue
+!! wikitext
+"{{uesc | v = <esc>{{#iargmap: iargmap | 2 | }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: iargmap | 2 | , }}</esc> | a | b | c | d }}"
+"{{uesc | v = <esc>{{#iargmap: iargmap | 2 | ,\n }}</esc> | a | b | c | d }}"
+!! html/php
+<p>"a!a!b!bc!c!d!d"
+"a!a!b!b,c!c!d!d"
+"a!a!b!b,
+c!c!d!d"
 </p>
 !! end

--- a/tests/parser/simpleFunctionsTest.txt
+++ b/tests/parser/simpleFunctionsTest.txt
@@ -43,6 +43,12 @@ Template:Iargmap
 {{{1}}}!{{{1|}}}!{{{2}}}!{{{2|}}}
 !! endarticle
 
+!! article
+Template:Id
+!! text
+{{{1}}}
+!! endarticle
+
 # NOTE: we use the following strings (concatenated) as parameter values below for testing some unescaping behaviors:
 #  - wikitext is not unescaped:          "\0"      -> "\0"
 #  - wikitext is unescaped only once:    "\\0"     -> "\0"
@@ -462,5 +468,23 @@ Target#X Target Target#Section
 "a!a!b!b,c!c!d!d"
 "a!a!b!b,
 c!c!d!d"
+</p>
+!! end
+
+!! test
+{{#arraymap}}
+!! wikitext
+"{{#arraymap:a,b,c|,|x|(xx)|!|?}}"
+!! html/php
+<p>"(aa)!(bb)&#160;? (cc)"
+</p>
+!! end
+
+!! test
+{{#arraymaptemplate}}
+!! wikitext
+"{{#arraymaptemplate:a,b,c|id|,|!}}"
+!! html/php
+<p>"a!b!c"
 </p>
 !! end


### PR DESCRIPTION
## Proposed changes

1. Add test cases for `#argmap` and `#iargmap`, only checking basic behavior for now.
2. Since the implementation of `#arraymap` and `#arraymaptemplate` is the same as *Page Forms*, add a (single) test case to ensure the functions and their parameters are properly registered.