### PR TITLE
refactor: Build `ParameterParser` from exposed parameter specification

### DIFF
--- a/src/Function/FollowFunction.php
+++ b/src/Function/FollowFunction.php
@@ -13,7 +13,7 @@ use MediaWiki\Title\Title;
 /**
  * Parser function for following page redirects (#follow).
  */
-final class FollowFunction implements ParserFunction {
+final class FollowFunction extends ParserFunctionBase {
 
 	/**
 	 * @param RedirectLookup $redirectLookup
@@ -33,11 +33,16 @@ final class FollowFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$text = trim( $params->get( 0 ) );
 
 		$title = Title::newFromText( $text );

--- a/src/Function/LinkPageFunction.php
+++ b/src/Function/LinkPageFunction.php
@@ -11,7 +11,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for replacing links with the name of the page they link to (#linkpage).
  */
-final class LinkPageFunction implements ParserFunction {
+final class LinkPageFunction extends ParserFunctionBase {
 
 	/**
 	 * Replace links with the name of the page they link to.
@@ -34,11 +34,16 @@ final class LinkPageFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => []
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'replace' ], $params->get( 0 ) );
 	}
 

--- a/src/Function/LinkTextFunction.php
+++ b/src/Function/LinkTextFunction.php
@@ -11,7 +11,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for replacing links with their appropriate link text (#linktext).
  */
-final class LinkTextFunction implements ParserFunction {
+final class LinkTextFunction extends ParserFunctionBase {
 
 	/**
 	 * Replace links with their appropriate link text.
@@ -38,11 +38,16 @@ final class LinkTextFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => []
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		return preg_replace_callback( '/\[\[(.*?)\]\]/', [ __CLASS__, 'replace' ], $params->get( 0 ) );
 	}
 

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -13,18 +13,32 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for filtering list values (#listfilter).
  */
-class ListFilterFunction implements ParserFunction {
+class ListFilterFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getName(): string {
 		return 'listfilter';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function allowsNamedParams(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return ListUtils::PARAM_OPTIONS;
 	}
 
 	/**
@@ -52,10 +66,7 @@ class ListFilterFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParameterParser::arrange( $frame, $params );
-		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
-
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -13,18 +13,32 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for mapping list values (#listmap).
  */
-class ListMapFunction implements ParserFunction {
+class ListMapFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getName(): string {
 		return 'listmap';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function allowsNamedParams(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return ListUtils::PARAM_OPTIONS;
 	}
 
 	/**
@@ -58,10 +72,7 @@ class ListMapFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParameterParser::arrange( $frame, $params );
-		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
-
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -13,18 +13,32 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for merging list values (#listmerge).
  */
-class ListMergeFunction implements ParserFunction {
+class ListMergeFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getName(): string {
 		return 'listmerge';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function allowsNamedParams(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return ListUtils::PARAM_OPTIONS;
 	}
 
 	/**
@@ -111,9 +125,7 @@ class ListMergeFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, ParameterParser::arrange( $frame, $params ), ListUtils::PARAM_OPTIONS );
-
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -13,18 +13,32 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for sorting list values (#listsort).
  */
-class ListSortFunction implements ParserFunction {
+class ListSortFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getName(): string {
 		return 'listsort';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function allowsNamedParams(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return ListUtils::PARAM_OPTIONS;
 	}
 
 	/**
@@ -68,10 +82,7 @@ class ListSortFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParameterParser::arrange( $frame, $params );
-		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
-
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -12,18 +12,32 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for removing non-unique list values (#listunique).
  */
-class ListUniqueFunction implements ParserFunction {
+class ListUniqueFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
 	 */
 	public function getName(): string {
 		return 'listunique';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function allowsNamedParams(): bool {
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return ListUtils::PARAM_OPTIONS;
 	}
 
 	/**
@@ -72,10 +86,7 @@ class ListUniqueFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = ParameterParser::arrange( $frame, $params );
-		$params = new ParameterParser( $frame, $params, ListUtils::PARAM_OPTIONS );
-
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 'list' );
 		$default = $params->get( 'default' );
 

--- a/src/Function/List/LstAppFunction.php
+++ b/src/Function/List/LstAppFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for appending a value to a list (#lstapp).
  */
-final class LstAppFunction implements ParserFunction {
+final class LstAppFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,13 +26,18 @@ final class LstAppFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			[ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$list = $params->get( 0 );
 		$value = $params->get( 2 );
 

--- a/src/Function/List/LstCntFunction.php
+++ b/src/Function/List/LstCntFunction.php
@@ -8,12 +8,12 @@ use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for counting values of a list (#lstcnt).
  */
-final class LstCntFunction implements ParserFunction {
+final class LstCntFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -25,12 +25,17 @@ final class LstCntFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$list = $params->get( 0 );
 		if ( $list === '' ) {
 			return '0';

--- a/src/Function/List/LstCntUniqFunction.php
+++ b/src/Function/List/LstCntUniqFunction.php
@@ -24,13 +24,25 @@ final class LstCntUniqFunction extends ListUniqueFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			[]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 		if ( $inList === '' ) {
 			return '0';

--- a/src/Function/List/LstElemFunction.php
+++ b/src/Function/List/LstElemFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for retrieving a value from a list (#lstelem).
  */
-final class LstElemFunction implements ParserFunction {
+final class LstElemFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,13 +26,18 @@ final class LstElemFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			[ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -26,16 +26,28 @@ final class LstFltrFunction extends ListFilterFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['keep'],
 			ListUtils::PARAM_OPTIONS['keepsep'],
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep'],
 			[]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 2 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstFndFunction.php
+++ b/src/Function/List/LstFndFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for searching a list value (#lstfnd).
  */
-final class LstFndFunction implements ParserFunction {
+final class LstFndFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,14 +26,19 @@ final class LstFndFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			[ 'unescape' => true ],
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			[]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$list = $params->get( 1 );
 
 		if ( $list === '' ) {

--- a/src/Function/List/LstIndFunction.php
+++ b/src/Function/List/LstIndFunction.php
@@ -8,12 +8,12 @@ use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for searching a list value index (#lstind).
  */
-final class LstIndFunction implements ParserFunction {
+final class LstIndFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -25,14 +25,19 @@ final class LstIndFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			[ 'unescape' => true ],
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			[]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$list = $params->get( 1 );
 
 		if ( $list === '' ) {

--- a/src/Function/List/LstJoinFunction.php
+++ b/src/Function/List/LstJoinFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for joining two lists (#lstjoin).
  */
-final class LstJoinFunction implements ParserFunction {
+final class LstJoinFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,15 +26,20 @@ final class LstJoinFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList1 = $params->get( 0 );
 		$inList2 = $params->get( 2 );
 		if ( $inList1 === '' && $inList2 === '' ) {

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -40,9 +40,16 @@ final class LstMapFunction extends ListMapFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
 		$legacyExpansionFlags = $this->useLegacyExpansion ? [ 'novars' => true ] : [];
-		$params = new ParameterParser( $frame, $params, [
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			array_merge( ListUtils::PARAM_OPTIONS['token'], [ 'default' => 'x' ], $legacyExpansionFlags ),
@@ -50,8 +57,13 @@ final class LstMapFunction extends ListMapFunction {
 			ListUtils::PARAM_OPTIONS['outsep'],
 			[],
 			ListUtils::PARAM_OPTIONS['sortoptions']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -27,16 +27,28 @@ final class LstMapTempFunction extends ListMapFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['template'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep'],
 			[],
 			ListUtils::PARAM_OPTIONS['sortoptions']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstPrepFunction.php
+++ b/src/Function/List/LstPrepFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for prepending a value to a list (#lstprep).
  */
-final class LstPrepFunction implements ParserFunction {
+final class LstPrepFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,13 +26,18 @@ final class LstPrepFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			[ 'unescape' => true ],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['list']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$value = $params->get( 0 );
 		$list = $params->get( 2 );
 

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -26,15 +26,27 @@ final class LstRmFunction extends ListFilterFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return [
 			[ 'unescape' => true ],
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep'],
 			[]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 1 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstSepFunction.php
+++ b/src/Function/List/LstSepFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for replacing the value separator of a list (#lstsep).
  */
-final class LstSepFunction implements ParserFunction {
+final class LstSepFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,13 +26,18 @@ final class LstSepFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 		if ( $inList === '' ) {
 			return '';

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -26,14 +26,26 @@ final class LstSrtFunction extends ListSortFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep'],
 			ListUtils::PARAM_OPTIONS['sortoptions']
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstSubFunction.php
+++ b/src/Function/List/LstSubFunction.php
@@ -9,12 +9,12 @@ use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
-use MediaWiki\Extension\ParserPower\Function\ParserFunction;
+use MediaWiki\Extension\ParserPower\Function\ParserFunctionBase;
 
 /**
  * Parser function for subdividing a list (#lstsub).
  */
-final class LstSubFunction implements ParserFunction {
+final class LstSubFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -26,15 +26,20 @@ final class LstSubFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep'],
 			[ 'unescape' => true ],
 			[ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -25,14 +25,26 @@ final class LstUniqFunction extends ListUniqueFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getParamSpec(): array {
+		return [
 			ListUtils::PARAM_OPTIONS['list'],
 			ListUtils::PARAM_OPTIONS['insep'],
 			ListUtils::PARAM_OPTIONS['outsep'],
 			[]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 0 );
 
 		if ( $inList === '' ) {

--- a/src/Function/OrFunction.php
+++ b/src/Function/OrFunction.php
@@ -11,7 +11,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for returning the 1st non-empty value (#or).
  */
-final class OrFunction implements ParserFunction {
+final class OrFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -23,9 +23,14 @@ final class OrFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params );
+	public function getDefaultSpec(): array {
+		return [];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		for ( $i = 0; $params->isDefined( $i ); ++$i ) {
 			$inValue = $params->get( $i );
 

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -1,0 +1,64 @@
+<?php
+
+/** @license GPL-2.0-or-later */
+
+namespace MediaWiki\Extension\ParserPower\Function;
+
+use MediaWiki\Extension\ParserPower\ParameterParser;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\PPFrame;
+
+/**
+ * Parser function, using a ParameterParser to manage its parameters.
+ */
+abstract class ParserFunctionBase implements ParserFunction {
+
+	/**
+	 * Whether named parameters are recognized, along with numbered parameters.
+	 *
+	 * @return bool
+	 */
+	public function allowsNamedParams(): bool {
+		return false;
+	}
+
+	/**
+	 * Get the list of parameter-specific parsing and post-processing options.
+	 *
+	 * @return array The list of parameter specifications.
+	 */
+	public function getParamSpec(): array {
+		return [];
+	}
+
+	/**
+	 * Get the parsing and post-processing options to use with unknown parameters.
+	 *
+	 * @return array A parameter specification.
+	 */
+	public function getDefaultSpec(): array {
+		return [];
+	}
+
+	/**
+	 * Perform the operations of the function, based on what parameter values are provided.
+	 *
+	 * @param Parser $parser Parser object.
+	 * @param PPFrame $frame Parser frame object.
+	 * @param ParameterParser $params Arranged function parameters.
+	 * @return string The function output.
+	 */
+	abstract public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function render( Parser $parser, PPFrame $frame, array $params ): string {
+		if ( $this->allowsNamedParams() ) {
+			$params = ParameterParser::arrange( $frame, $params );
+		}
+
+		$params = new ParameterParser( $frame, $params, $this->getParamSpec(), $this->getDefaultSpec() );
+		return $this->execute( $parser, $frame, $params );
+	}
+}

--- a/src/Function/TokenFunction.php
+++ b/src/Function/TokenFunction.php
@@ -12,7 +12,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for replacing a token in a pattern (#token).
  */
-final class TokenFunction implements ParserFunction {
+final class TokenFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -24,13 +24,18 @@ final class TokenFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [],
 			1 => [ 'default' => 'x', 'unescape' => true ],
 			2 => [ 'default' => 'x', 'novars' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$outValue = ParserPower::applyPattern( $params->get( 0 ), $params->get( 1 ), $params->get( 2 ) );
 		$outValue = $parser->preprocessToDom( $outValue, $frame->isTemplate() ? Parser::PTD_FOR_INCLUSION : 0 );
 		$outValue = ParserPower::expand( $frame, $outValue, ParserPower::UNESCAPE );

--- a/src/Function/TokenIfFunction.php
+++ b/src/Function/TokenIfFunction.php
@@ -12,7 +12,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for nesting #token in #if (#tokenif).
  */
-final class TokenIfFunction implements ParserFunction {
+final class TokenIfFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -24,14 +24,19 @@ final class TokenIfFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [],
 			1 => [ 'default' => 'x', 'unescape' => true ],
 			2 => [ 'default' => 'x', 'novars' => true ],
 			3 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inValue = $params->get( 0 );
 		if ( $inValue === '' ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 3 ) );

--- a/src/Function/TrimFunction.php
+++ b/src/Function/TrimFunction.php
@@ -11,7 +11,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for trimming a value (#trim).
  */
-final class TrimFunction implements ParserFunction {
+final class TrimFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -23,11 +23,16 @@ final class TrimFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => []
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		return $params->get( 0 );
 	}
 }

--- a/src/Function/TrimUescFunction.php
+++ b/src/Function/TrimUescFunction.php
@@ -13,7 +13,7 @@ use MediaWiki\Parser\PPFrame;
  * Parser function for unescaping then trimming a value (#trimuesc),
  * so any leading or trailing whitespace is trimmed no matter how it got there.
  */
-final class TrimUescFunction implements ParserFunction {
+final class TrimUescFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -25,11 +25,16 @@ final class TrimUescFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$text = trim( $params->get( 0 ) );
 
 		return ParserPower::evaluateUnescaped( $parser, $frame, $text );

--- a/src/Function/UeIfFunction.php
+++ b/src/Function/UeIfFunction.php
@@ -12,7 +12,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for #if with unescaped parameters (#ueif).
  */
-final class UeIfFunction implements ParserFunction {
+final class UeIfFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -24,13 +24,18 @@ final class UeIfFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [],
 			1 => [ 'unescape' => true ],
 			2 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		if ( $params->get( 0 ) !== '' ) {
 			$value = $params->get( 1 );
 		} else {

--- a/src/Function/UeIfeqFunction.php
+++ b/src/Function/UeIfeqFunction.php
@@ -12,7 +12,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for #ifeq with unescaped parameters (#ueifeq).
  */
-final class UeIfeqFunction implements ParserFunction {
+final class UeIfeqFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -24,14 +24,19 @@ final class UeIfeqFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [ 'unescape' => true ],
 			1 => [ 'unescape' => true ],
 			2 => [ 'unescape' => true ],
 			3 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		if ( $params->get( 0 ) === $params->get( 1 ) ) {
 			$value = $params->get( 2 );
 		} else {

--- a/src/Function/UeOrFunction.php
+++ b/src/Function/UeOrFunction.php
@@ -12,7 +12,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for #or with unescaped parameters (#ueor).
  */
-final class UeOrFunction implements ParserFunction {
+final class UeOrFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -24,9 +24,14 @@ final class UeOrFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params );
+	public function getDefaultSpec(): array {
+		return [];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		for ( $i = 0; $params->isDefined( $i ); ++$i ) {
 			$inValue = $params->get( $i );
 

--- a/src/Function/UescFunction.php
+++ b/src/Function/UescFunction.php
@@ -12,7 +12,7 @@ use MediaWiki\Parser\PPFrame;
 /**
  * Parser function for unescaping a value (#uesc).
  */
-final class UescFunction implements ParserFunction {
+final class UescFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -24,11 +24,16 @@ final class UescFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 0 ) );
 	}
 }

--- a/src/Function/UescNowikiFunction.php
+++ b/src/Function/UescNowikiFunction.php
@@ -13,7 +13,7 @@ use MediaWiki\Parser\PPFrame;
  * Parser function for unescaping then wrapping in <nowiki> tags a value (#uescnowiki),
  * so that it isn't parsed.
  */
-final class UescNowikiFunction implements ParserFunction {
+final class UescNowikiFunction extends ParserFunctionBase {
 
 	/**
 	 * @inheritDoc
@@ -25,11 +25,16 @@ final class UescNowikiFunction implements ParserFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = new ParameterParser( $frame, $params, [
+	public function getParamSpec(): array {
+		return [
 			0 => [ 'unescape' => true ]
-		] );
+		];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		return ParserPower::evaluateUnescaped( $parser, $frame, '<nowiki>' . $params->get( 0 ) . '</nowiki>' );
 	}
 }


### PR DESCRIPTION
## Proposed changes

Add a `ParserFunctionBase` abstract implementation of `ParserFunction`, that directly provides a `ParameterParser` as argument when run (instead of a raw `array` of indexed parameters).

Final parser function implementations can then specify their parameter specifications (the `ParameterParser` constructor arguments) as additional methods (i.e. `allowsNamedParams()`, `getParamSpec()`, or `getDefaultSpec()`).

## Motivations

This would allow parser functions to share the same behavior, but with a different parameter naming scheme / ordering in the future (such as making `#lstmap` work exactly like `#listmap`, but with different numbered parameter aliases).