### PR TITLE
Move `#argmap`/`#iargmap` error messages to system messages

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,8 +6,9 @@
 	},
 	"parserpower": "The name of the extension's entry in Special:SpecialPages",
 	"parserpower-desc": "A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter.",
-	"parserpower-error-invalid-argument-number": "$1 error: The number of given formatter arguments must be divisible by \"$2\".",
-	"parserpower-error-invalid-integer": "$1 error: \"$2\" must be an integer.",
-	"parserpower-error-missing-parameter": "$1 error: The parameter \"$2\" is required.",
-	"parserpower-error-no-arguments": "$1 error: No formatter arguments were given."
+	"parserpower-error": "$1 error: $2",
+	"parserpower-error-invalid-argument-number": "The number of given formatter arguments must be divisible by \"$1\".",
+	"parserpower-error-invalid-integer": "\"$1\" must be an integer.",
+	"parserpower-error-missing-parameter": "The parameter \"$1\" is required.",
+	"parserpower-error-no-arguments": "No formatter arguments were given."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,5 +5,9 @@
 		]
 	},
 	"parserpower": "The name of the extension's entry in Special:SpecialPages",
-	"parserpower-desc": "A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter."
+	"parserpower-desc": "A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter.",
+	"parserpower-error-invalid-argument-number": "$1 error: The number of given formatter arguments must be divisible by \"$2\".",
+	"parserpower-error-invalid-integer": "$1 error: \"$2\" must be an integer.",
+	"parserpower-error-missing-parameter": "$1 error: The parameter \"$2\" is required.",
+	"parserpower-error-no-arguments": "$1 error: No formatter arguments were given."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,10 +1,9 @@
 {
-  "@metadata" : {
-    "authors" : [
-      "OOeyes"
-    ]
-  },
-  "parserpower"                 : "The name of the extension's entry in Special:SpecialPages",
-  "parserpower-desc"            : "A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter."
+	"@metadata" : {
+		"authors" : [
+			"OOeyes"
+		]
+	},
+	"parserpower": "The name of the extension's entry in Special:SpecialPages",
+	"parserpower-desc": "A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter."
 }
-

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,3 +1,3 @@
 {
-  "name": "sbruck"
+	"name": "sbruck"
 }

--- a/src/Function/ArgMapFunction.php
+++ b/src/Function/ArgMapFunction.php
@@ -23,8 +23,7 @@ final class ArgMapFunction implements ParserFunction {
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
-			$message = ParserPower::newMessage( 'error-missing-parameter', 'argmap', 'formatter' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'missing-parameter', 'argmap', 'formatter' );
 		}
 
 		// set parameters

--- a/src/Function/ArgMapFunction.php
+++ b/src/Function/ArgMapFunction.php
@@ -23,7 +23,7 @@ final class ArgMapFunction implements ParserFunction {
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
-			return ParserPower::errorMessage( 'missing-parameter', 'argmap', 'formatter' );
+			return ParserPower::errorMessage( 'argmap', 'missing-parameter', 'formatter' );
 		}
 
 		// set parameters

--- a/src/Function/ArgMapFunction.php
+++ b/src/Function/ArgMapFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 use MediaWiki\Parser\PPNode_Hash_Array;
@@ -22,7 +23,8 @@ final class ArgMapFunction implements ParserFunction {
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
-			return '<strong class="error">argmap error: The parameter "formatter" is required.</strong>';
+			$message = ParserPower::newMessage( 'error-missing-parameter', 'argmap', 'formatter' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 
 		// set parameters

--- a/src/Function/IArgMapFunction.php
+++ b/src/Function/IArgMapFunction.php
@@ -23,12 +23,10 @@ final class IArgMapFunction implements ParserFunction {
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
-			$message = ParserPower::newMessage( 'error-missing-parameter', 'iargmap', 'formatter' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'missing-parameter', 'iargmap', 'formatter' );
 		}
 		if ( !isset( $args[1] ) ) {
-			$message = ParserPower::newMessage( 'error-missing-parameter', 'iargmap', 'n' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'missing-parameter', 'iargmap', 'n' );
 		}
 
 		// set parameters
@@ -39,24 +37,20 @@ final class IArgMapFunction implements ParserFunction {
 
 		// check against bad entries
 		if ( count( $allFormatterArgs ) == 0 ) {
-			$message = ParserPower::newMessage( 'error-no-arguments', 'iargmap' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'no-arguments', 'iargmap', 'n' );
 		}
 		if ( !is_numeric( $numberOfArgumentsPerFormatter ) ) {
-			$message = ParserPower::newMessage( 'error-invalid-integer', 'iargmap', 'n' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'invalid-integer', 'iargmap', 'n' );
 		}
 
 		if ( intval( $numberOfArgumentsPerFormatter ) != floatval( $numberOfArgumentsPerFormatter ) ) {
-			$message = ParserPower::newMessage( 'error-invalid-integer', 'iargmap', 'n' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'invalid-integer', 'iargmap', 'n' );
 		}
 
 		$imax = count( $allFormatterArgs ) / intval( $numberOfArgumentsPerFormatter );
 
 		if ( !is_int( $imax ) ) {
-			$message = ParserPower::newMessage( 'error-invalid-argument-number', 'iargmap', 'n' );
-			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+			return ParserPower::errorMessage( 'invalid-argument-number', 'iargmap', 'n' );
 		}
 
 		// write formatter calls

--- a/src/Function/IArgMapFunction.php
+++ b/src/Function/IArgMapFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function;
 
+use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 use MediaWiki\Parser\PPNode_Hash_Array;
@@ -22,10 +23,12 @@ final class IArgMapFunction implements ParserFunction {
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
-			return '<strong class="error">iargmap error: The parameter "formatter" is required.</strong>';
+			$message = ParserPower::newMessage( 'error-missing-parameter', 'iargmap', 'formatter' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 		if ( !isset( $args[1] ) ) {
-			return '<strong class="error">iargmap error: The parameter "n" is required.</strong>';
+			$message = ParserPower::newMessage( 'error-missing-parameter', 'iargmap', 'n' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 
 		// set parameters
@@ -36,20 +39,24 @@ final class IArgMapFunction implements ParserFunction {
 
 		// check against bad entries
 		if ( count( $allFormatterArgs ) == 0 ) {
-			return '<strong class="error">iargmap error: No formatter arguments were given.</strong>';
+			$message = ParserPower::newMessage( 'error-no-arguments', 'iargmap' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 		if ( !is_numeric( $numberOfArgumentsPerFormatter ) ) {
-			return '<strong class="error">iargmap error: "n" must be an integer.</strong>';
+			$message = ParserPower::newMessage( 'error-invalid-integer', 'iargmap', 'n' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 
 		if ( intval( $numberOfArgumentsPerFormatter ) != floatval( $numberOfArgumentsPerFormatter ) ) {
-			return '<strong class="error">iargmap error: "n" must be an integer.</strong>';
+			$message = ParserPower::newMessage( 'error-invalid-integer', 'iargmap', 'n' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 
 		$imax = count( $allFormatterArgs ) / intval( $numberOfArgumentsPerFormatter );
 
 		if ( !is_int( $imax ) ) {
-			return '<strong class="error">iargmap error: The number of given formatter arguments must be divisible by "n".</strong>';
+			$message = ParserPower::newMessage( 'error-invalid-argument-number', 'iargmap', 'n' );
+			return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
 		}
 
 		// write formatter calls

--- a/src/Function/IArgMapFunction.php
+++ b/src/Function/IArgMapFunction.php
@@ -23,10 +23,10 @@ final class IArgMapFunction implements ParserFunction {
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 		if ( !isset( $args[0] ) ) {
-			return ParserPower::errorMessage( 'missing-parameter', 'iargmap', 'formatter' );
+			return ParserPower::errorMessage( 'iargmap', 'missing-parameter', 'formatter' );
 		}
 		if ( !isset( $args[1] ) ) {
-			return ParserPower::errorMessage( 'missing-parameter', 'iargmap', 'n' );
+			return ParserPower::errorMessage( 'iargmap', 'missing-parameter', 'n' );
 		}
 
 		// set parameters
@@ -37,20 +37,20 @@ final class IArgMapFunction implements ParserFunction {
 
 		// check against bad entries
 		if ( count( $allFormatterArgs ) == 0 ) {
-			return ParserPower::errorMessage( 'no-arguments', 'iargmap', 'n' );
+			return ParserPower::errorMessage( 'iargmap', 'no-arguments', 'n' );
 		}
 		if ( !is_numeric( $numberOfArgumentsPerFormatter ) ) {
-			return ParserPower::errorMessage( 'invalid-integer', 'iargmap', 'n' );
+			return ParserPower::errorMessage( 'iargmap', 'invalid-integer', 'n' );
 		}
 
 		if ( intval( $numberOfArgumentsPerFormatter ) != floatval( $numberOfArgumentsPerFormatter ) ) {
-			return ParserPower::errorMessage( 'invalid-integer', 'iargmap', 'n' );
+			return ParserPower::errorMessage( 'iargmap', 'invalid-integer', 'n' );
 		}
 
 		$imax = count( $allFormatterArgs ) / intval( $numberOfArgumentsPerFormatter );
 
 		if ( !is_int( $imax ) ) {
-			return ParserPower::errorMessage( 'invalid-argument-number', 'iargmap', 'n' );
+			return ParserPower::errorMessage( 'iargmap', 'invalid-argument-number', 'n' );
 		}
 
 		// write formatter calls

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -232,4 +232,16 @@ class ParserPower {
 	public static function newMessage( string $key, ...$params ): Message {
 		return wfMessage( 'parserpower-' . $key, ...$params );
 	}
+
+	/**
+	 * Returns a ParserPower error message formatted as wikitext (with variables replaced).
+	 *
+	 * @param string $key Error message key, without its "error-" prefix.
+	 * @param mixed ...$params Error message parameters.
+	 * @return string The formatted message text.
+	 */
+	public static function errorMessage( string $key, ...$params ): string {
+		$message = ParserPower::newMessage( 'error-' . $key, ...$params );
+		return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+	}
 }

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -236,12 +236,14 @@ class ParserPower {
 	/**
 	 * Returns a ParserPower error message formatted as wikitext (with variables replaced).
 	 *
+	 * @param string $origin Error origin, basically a parser function or tag name.
 	 * @param string $key Error message key, without its "error-" prefix.
 	 * @param mixed ...$params Error message parameters.
 	 * @return string The formatted message text.
 	 */
-	public static function errorMessage( string $key, ...$params ): string {
-		$message = ParserPower::newMessage( 'error-' . $key, ...$params );
-		return '<strong class="error">' . $message->inContentLanguage()->text() . '</strong>';
+	public static function errorMessage( string $origin, string $key, ...$params ): string {
+		$innerMessage = ParserPower::newMessage( 'error-' . $key, $params );
+		$outerMessage = ParserPower::newMessage( 'error', $origin, $innerMessage );
+		return '<strong class="error">' . $outerMessage->inContentLanguage()->text() . '</strong>';
 	}
 }

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -4,12 +4,14 @@
 
 namespace MediaWiki\Extension\ParserPower;
 
+use MediaWiki\Message\Message;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 use MediaWiki\Parser\PPNode;
 use MediaWiki\Parser\Preprocessor;
 
 class ParserPower {
+
 	/**
 	 * expand() flag for not expanding variables.
 	 */
@@ -218,5 +220,16 @@ class ParserPower {
 		} else {
 			return str_replace( $token, $value, $pattern );
 		}
+	}
+
+	/**
+	 * Create a ParserPower-specific message.
+	 * 
+	 * @param string $key Message key.
+	 * @param mixed ...$params Message parameters.
+	 * @return Message The ParserPower message.
+	 */
+	public static function newMessage( string $key, ...$params ): Message {
+		return wfMessage( 'parserpower-' . $key, ...$params );
 	}
 }


### PR DESCRIPTION
## Context

The `#argmap` and `#iargmap` functions can throw an error if some of their parameters are missing or not following a specific format. In which case, the parser functions return an error message within a `<strong class="error">` tag.

## Proposed changes

Add a `parserpower-error-…` system message for each `#argmap`/`#iargmap` error message. Also add a generic `parserpower-error` message for the base error message formatting.

## Why

1. Allow replacing the base error message format on specific wikis (by overriding `mediawiki:parserpower-error`).
2. Allow any non-EN wiki to provide its own error message translations (by overriding the `parserpower-error-…` messages).