### PR TITLE
refactor: Reuse `#listmap`/`#listsort` implementation in `#lstmap`/`#lstmaptemp`/`#lstsrt`

### DIFF
--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -65,41 +65,4 @@ final class LstMapFunction extends ListMapFunction {
 
 		return $paramSpec;
 	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
-		$inList = $params->get( 'list' );
-		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$inValues = ListUtils::explode( $inSep, $inList );
-
-		if ( count( $inValues ) === 0 ) {
-			return '';
-		}
-
-		$token = $params->get( 'token' );
-		$pattern = $params->get( 'pattern' );
-
-		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
-		$sortOptions = $sortMode > 0 ? ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) ) : 0;
-		$sorter = new ListSorter( $sortOptions );
-
-		if ( $sortMode & ListUtils::SORTMODE_PRE ) {
-			$inValues = $sorter->sort( $inValues );
-		}
-
-		$operation = new PatternOperation( $parser, $frame, $pattern, [ $token ] );
-		$outValues = $this->mapList( $operation, false, $inValues, '' );
-
-		if ( $sortMode & ( ListUtils::SORTMODE_COMPAT | ListUtils::SORTMODE_POST ) ) {
-			$outValues = $sorter->sort( $outValues );
-		}
-
-		$outSep = count( $outValues ) > 1 ? $params->get( 'outsep' ) : '';
-		$outList = ListUtils::implode( $outValues, $outSep );
-
-		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
-	}
 }

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -45,40 +45,4 @@ final class LstMapTempFunction extends ListMapFunction {
 			5 => 'sortoptions'
 		];
 	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
-		$inList = $params->get( 'list' );
-		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$inValues = ListUtils::explode( $inSep, $inList );
-
-		if ( count( $inValues ) === 0 ) {
-			return '';
-		}
-
-		$template = $params->get( 'template' );
-
-		$sortMode = ListUtils::decodeSortMode( $params->get( 'sortmode' ) );
-		$sortOptions = $sortMode > 0 ? ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) ) : 0;
-		$sorter = new ListSorter( $sortOptions );
-
-		if ( $sortMode & ListUtils::SORTMODE_PRE ) {
-			$inValues = $sorter->sort( $inValues );
-		}
-
-		$operation = new TemplateOperation( $parser, $frame, $template );
-		$outValues = $this->mapList( $operation, true, $inValues, '' );
-
-		if ( $sortMode & ( ListUtils::SORTMODE_POST | ListUtils::SORTMODE_COMPAT ) ) {
-			$outValues = $sorter->sort( $outValues );
-		}
-
-		$outSep = count( $outValues ) > 1 ? $params->get( 'outsep' ) : '';
-		$outList = ListUtils::implode( $outValues, $outSep );
-
-		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
-	}
 }

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -42,27 +42,4 @@ final class LstSrtFunction extends ListSortFunction {
 			3 => 'sortoptions'
 		];
 	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
-		$inList = $params->get( 'list' );
-		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$values = ListUtils::explode( $inSep, $inList );
-
-		if ( count( $values ) === 0 ) {
-			return '';
-		}
-
-		$sortOptions = ListUtils::decodeSortOptions( $params->get( 'sortoptions' ) );
-		$sorter = new ListSorter( $sortOptions );
-		$values = $sorter->sort( $values );
-
-		$outSep = count( $values ) > 1 ? $params->get( 'outsep' ) : '';
-		$outList = ListUtils::implode( $values, $outSep );
-
-		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
-	}
 }


### PR DESCRIPTION
Since #48 makes `#lstmap`/`#lstmaptemp` share the same base parameters as `#listmap` and `#lstsrt` as `#listsort`, make `#lstmap`/`#lstmaptemp`/`#lstsrt` inherit their `execute()` behavior from `#listmap`/`#listsort`.