### PR TITLE
feat: Add a tracking category for pages with duplicated function parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Add new entries to the top of the 1.x.x-NEXT section.
 * Added `outconj` optional parameter to `#listmap`. If defined, its value is unescaped then trimmed, and will be used as delimiter for the last 2 output list values.
 * List functions now evaluate most of their parameters lazily. Parameter evaluation order may have changed, and side effects may no longer be applied inside unused parameters.
 * `#listmerge` no longer ignores `mergetemplate` or `matchtemplate` if the other one is unspecified.
+* Added `parserpower-duplicate-args-category` system message. It defines a tracking category added to pages using ParserPower parser functions with a same numbered and/or named parameter defined multiple times.
 * …
 
 ### 1.6.1 (2025-04-27)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,5 +11,5 @@
 	"parserpower-error-invalid-integer": "\"$1\" must be an integer.",
 	"parserpower-error-missing-parameter": "The parameter \"$1\" is required.",
 	"parserpower-error-no-arguments": "No formatter arguments were given.",
-	"parserpower-duplicate-args-category": "Pages using duplicate arguments in ParserPower function call"
+	"parserpower-duplicate-args-category": "Pages using duplicate arguments in ParserPower functions"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -10,5 +10,6 @@
 	"parserpower-error-invalid-argument-number": "The number of given formatter arguments must be divisible by \"$1\".",
 	"parserpower-error-invalid-integer": "\"$1\" must be an integer.",
 	"parserpower-error-missing-parameter": "The parameter \"$1\" is required.",
-	"parserpower-error-no-arguments": "No formatter arguments were given."
+	"parserpower-error-no-arguments": "No formatter arguments were given.",
+	"parserpower-duplicate-args-category": "Pages using duplicate arguments in ParserPower function call"
 }

--- a/src/Function/FollowFunction.php
+++ b/src/Function/FollowFunction.php
@@ -21,6 +21,7 @@ final class FollowFunction extends ParserFunctionBase {
 	public function __construct(
 		private readonly RedirectLookup $redirectLookup
 	) {
+		parent::__construct();
 	}
 
 	/**

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -28,6 +28,7 @@ final class LstMapFunction extends ListMapFunction {
 	 */
 	public function __construct( ParserPowerConfig $config ) {
 		$this->useLegacyExpansion = $config->get( 'LstmapExpansionCompat' );
+		parent::__construct();
 	}
 
 	/**

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -15,17 +15,16 @@ use MediaWiki\Parser\PPFrame;
  */
 abstract class ParserFunctionBase implements ParserFunction {
 
-	private ParameterParserFactory $paramsFactory;
+	private readonly ParameterParserFactory $paramsFactory;
 
 	public function __construct() {
-		$this->paramsFactory = MediaWikiServices::getInstance()->getService( 'ParserPower.ParameterParserFactory' );
-
 		$paramFlags = 0;
 		if ( $this->allowsNamedParams() ) {
 			$paramFlags |= ParameterParser::ALLOWS_NAMED;
 		}
 
-		$this->paramsFactory = $this->paramsFactory->withOptions( $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
+		$this->paramsFactory = MediaWikiServices::getInstance()->getService( 'ParserPower.ParameterParserFactory' )
+			->withOptions( $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
 	}
 
 	/**

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -23,8 +23,7 @@ abstract class ParserFunctionBase implements ParserFunction {
 			$paramFlags |= ParameterParser::ALLOWS_NAMED;
 		}
 
-		$this->paramsFactory = MediaWikiServices::getInstance()->getService( 'ParserPower.ParameterParserFactory' )
-			->withOptions( $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
+		$this->paramsFactory = new ParameterParserFactory( $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
 	}
 
 	/**

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -69,7 +69,7 @@ abstract class ParserFunctionBase implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$params = $this->paramsFactory->newParameterParser( $frame, $params );
+		$params = $this->paramsFactory->newParameterParser( $parser, $frame, $params );
 		return $this->execute( $parser, $frame, $params );
 	}
 }

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -5,6 +5,8 @@
 namespace MediaWiki\Extension\ParserPower\Function;
 
 use MediaWiki\Extension\ParserPower\ParameterParser;
+use MediaWiki\Extension\ParserPower\ParameterParserFactory;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -12,6 +14,19 @@ use MediaWiki\Parser\PPFrame;
  * Parser function, using a ParameterParser to manage its parameters.
  */
 abstract class ParserFunctionBase implements ParserFunction {
+
+	private ParameterParserFactory $paramsFactory;
+
+	public function __construct() {
+		$this->paramsFactory = MediaWikiServices::getInstance()->getService( 'ParserPower.ParameterParserFactory' );
+
+		$paramFlags = 0;
+		if ( $this->allowsNamedParams() ) {
+			$paramFlags |= ParameterParser::ALLOWS_NAMED;
+		}
+
+		$this->paramsFactory = $this->paramsFactory->withOptions( $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
+	}
 
 	/**
 	 * Whether named parameters are recognized, along with numbered parameters.
@@ -54,12 +69,7 @@ abstract class ParserFunctionBase implements ParserFunction {
 	 * @inheritDoc
 	 */
 	public function render( Parser $parser, PPFrame $frame, array $params ): string {
-		$paramFlags = 0;
-		if ( $this->allowsNamedParams() ) {
-			$paramFlags |= ParameterParser::ALLOWS_NAMED;
-		}
-
-		$params = new ParameterParser( $frame, $params, $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
+		$params = $this->paramsFactory->newParameterParser( $frame, $params );
 		return $this->execute( $parser, $frame, $params );
 	}
 }

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower;
 
+use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
 /**
@@ -36,6 +37,7 @@ final class ParameterParser {
 	private array $expandedParams = [];
 
 	/**
+	 * @param Parser $parser Parser object.
 	 * @param PPFrame $frame Parser frame object.
 	 * @param array $rawParams Unexpanded parameters.
 	 * @param array $paramOptions Parsing and post-processing options for all parameters.
@@ -43,6 +45,7 @@ final class ParameterParser {
 	 * @param int $flags Parameter parser flags.
 	 */
 	public function __construct(
+		private readonly Parser $parser,
 		private readonly PPFrame $frame,
 		private array $rawParams,
 		private array $paramOptions = [],

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -84,6 +84,10 @@ final class ParameterParser {
 				$key = $options['alias'];
 			}
 
+			if ( isset( $this->params[$key] ) ) {
+				$parser->addTrackingCategory( 'parserpower-duplicate-args-category' );
+			}
+
 			$this->params[$key] = $value;
 		}
 	}

--- a/src/ParameterParserFactory.php
+++ b/src/ParameterParserFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/** @license GPL-2.0-or-later */
+
+namespace MediaWiki\Extension\ParserPower;
+
+use MediaWiki\Parser\PPFrame;
+
+/**
+ * Factory class to create ParameterParser objects.
+ */
+final class ParameterParserFactory {
+
+	/**
+	 * @param array $paramOptions Parsing and post-processing options for all parameters.
+	 * @param array $defaultOptions Parsing and post-processing options for unknown parameters.
+	 * @param int $flags Parameter parser flags.
+	 */
+	public function __construct(
+		private array $paramOptions = [],
+		private array $defaultOptions = [],
+		private int $flags = 0
+	) {
+	}
+
+	/**
+	 * Returns a new factory using different options.
+	 *
+	 * @param array $paramOptions Parsing and post-processing options for all parameters.
+	 * @param array $defaultOptions Parsing and post-processing options for unknown parameters.
+	 * @param int $flags Parameter parser flags.
+	 * @return ParameterParserFactory The new factory.
+	 */
+	public function withOptions( array $paramOptions, array $defaultOptions = [], int $flags = 0 ): ParameterParserFactory {
+		return new ParameterParserFactory( $paramOptions, $defaultOptions, $flags );
+	}
+
+	/**
+	 * Create a parameter parser.
+	 *
+	 * @param PPFrame $frame Parser frame object.
+	 * @param array $rawParams Unexpanded parameters.
+	 * @return ParameterParser A parameter parser.
+	 */
+	public function newParameterParser( PPFrame $frame, array $rawParams ): ParameterParser {
+		return new ParameterParser( $frame, $rawParams, $this->paramOptions, $this->defaultOptions, $this->flags );
+	}
+}

--- a/src/ParameterParserFactory.php
+++ b/src/ParameterParserFactory.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower;
 
+use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
 /**
@@ -38,11 +39,12 @@ final class ParameterParserFactory {
 	/**
 	 * Create a parameter parser.
 	 *
+	 * @param Parser $parser Parser object.
 	 * @param PPFrame $frame Parser frame object.
 	 * @param array $rawParams Unexpanded parameters.
 	 * @return ParameterParser A parameter parser.
 	 */
-	public function newParameterParser( PPFrame $frame, array $rawParams ): ParameterParser {
-		return new ParameterParser( $frame, $rawParams, $this->paramOptions, $this->defaultOptions, $this->flags );
+	public function newParameterParser( Parser $parser, PPFrame $frame, array $rawParams ): ParameterParser {
+		return new ParameterParser( $parser, $frame, $rawParams, $this->paramOptions, $this->defaultOptions, $this->flags );
 	}
 }

--- a/src/ParameterParserFactory.php
+++ b/src/ParameterParserFactory.php
@@ -25,18 +25,6 @@ final class ParameterParserFactory {
 	}
 
 	/**
-	 * Returns a new factory using different options.
-	 *
-	 * @param array $paramOptions Parsing and post-processing options for all parameters.
-	 * @param array $defaultOptions Parsing and post-processing options for unknown parameters.
-	 * @param int $flags Parameter parser flags.
-	 * @return ParameterParserFactory The new factory.
-	 */
-	public function withOptions( array $paramOptions, array $defaultOptions = [], int $flags = 0 ): ParameterParserFactory {
-		return new ParameterParserFactory( $paramOptions, $defaultOptions, $flags );
-	}
-
-	/**
 	 * Create a parameter parser.
 	 *
 	 * @param Parser $parser Parser object.

--- a/src/ServiceWiring.php
+++ b/src/ServiceWiring.php
@@ -3,17 +3,12 @@
 /** @license GPL-2.0-or-later */
 
 use MediaWiki\Config\Config;
-use MediaWiki\Extension\ParserPower\ParameterParserFactory;
 use MediaWiki\Extension\ParserPower\ParserVariableRegistry;
 use MediaWiki\MediaWikiServices;
 
 return [
 	'ParserPower.Config' => static function ( MediaWikiServices $services ): Config {
 		return $services->getConfigFactory()->makeConfig( 'ParserPower' );
-	},
-
-	'ParserPower.ParameterParserFactory' => static function (): ParameterParserFactory {
-		return new ParameterParserFactory();
 	},
 
 	'ParserPower.ParserVariableRegistry' => static function ( MediaWikiServices $services ): ParserVariableRegistry {

--- a/src/ServiceWiring.php
+++ b/src/ServiceWiring.php
@@ -3,12 +3,17 @@
 /** @license GPL-2.0-or-later */
 
 use MediaWiki\Config\Config;
+use MediaWiki\Extension\ParserPower\ParameterParserFactory;
 use MediaWiki\Extension\ParserPower\ParserVariableRegistry;
 use MediaWiki\MediaWikiServices;
 
 return [
 	'ParserPower.Config' => static function ( MediaWikiServices $services ): Config {
 		return $services->getConfigFactory()->makeConfig( 'ParserPower' );
+	},
+
+	'ParserPower.ParameterParserFactory' => static function (): ParameterParserFactory {
+		return new ParameterParserFactory();
 	},
 
 	'ParserPower.ParserVariableRegistry' => static function ( MediaWikiServices $services ): ParserVariableRegistry {


### PR DESCRIPTION
## Context

Some list functions accept named parameters and aliases (since #48), meaning users can specify a same parameter twice, with the same name/number or one of its aliases.

## Proposed changes

Add a tracking category to pages using ParserPower parser functions, when 2 specified function parameters set the same parameter in practice (with the same name/number or with alias usage).

This category is defined by the `MediaWiki:Parserpower-duplicate-args-category` message, and defaults to `Pages using duplicate arguments in ParserPower function call`.

On the implementation side, also add a `ParameterParserFactory` service to simplify `ParameterParser` usage with similar parameter options/flags and help with dependency injection.