### PR TITLE
fix: `#listunique`: Kill `nowiki` strip markers in `insep`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Add new entries to the top of the 1.x.x-NEXT section.
 * Added `outconj` optional parameter to `#listmap`. If defined, its value is unescaped then trimmed, and will be used as delimiter for the last 2 output list values.
 * List functions now evaluate most of their parameters lazily. Parameter evaluation order may have changed, and side effects may no longer be applied inside unused parameters.
 * `#listmerge` no longer ignores `mergetemplate` or `matchtemplate` if the other one is unspecified.
+* `#listunique` now removes `nowiki` strip markers from its `insep` parameter.
 * …
 
 ### 1.6.1 (2025-04-27)

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -89,6 +89,7 @@ class ListUniqueFunction extends ParserFunctionBase {
 	public function execute( Parser $parser, PPFrame $frame, ParameterParser $params ): string {
 		$inList = $params->get( 'list' );
 		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
+		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 
 		if ( count( $inValues ) === 0 ) {


### PR DESCRIPTION
## Context

All PowerPower list functions remove `<nowiki>` strip markers from their input list separator(s). This is specifically not the case for the `#listunique` function.

## Proposed changes

Make `#listunique` remove `nowiki` strip markers from its `insep` parameter.