### PR TITLE
Cleanup i18n messages

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,5 +1,6 @@
 {
 	"name": "ParserPower",
+	"namemsg": "parserpower",
 	"version": "1.7.0",
 	"author": [
 		"[http://www.mediawiki.org/wiki/User:OoEyes Shawn Bruckner]",

--- a/extension.json
+++ b/extension.json
@@ -19,6 +19,9 @@
 			"php": ">= 8.1"
 		}
 	},
+	"TrackingCategories": [
+		"parserpower-duplicate-args-category"
+	],
 	"MessagesDirs": {
 		"ParserPower": [
 			"i18n"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -11,5 +11,6 @@
 	"parserpower-error-invalid-integer": "\"$1\" must be an integer.",
 	"parserpower-error-missing-parameter": "The parameter \"$1\" is required.",
 	"parserpower-error-no-arguments": "No formatter arguments were given.",
-	"parserpower-duplicate-args-category": "Pages using duplicate arguments in ParserPower functions"
+	"parserpower-duplicate-args-category": "Pages using duplicate arguments in ParserPower functions",
+	"parserpower-duplicate-args-category-desc": "The page contains ParserPower function calls that use duplicates of arguments."
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,7 +1,10 @@
 {
 	"@metadata" : {
 		"authors" : [
-			"OOeyes"
+			"OOeyes",
+			"Hydra Wiki Platform Team",
+			"wiki.gg development team",
+			"Derugon"
 		]
 	},
 	"parserpower": "ParserPower",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,7 +4,7 @@
 			"OOeyes"
 		]
 	},
-	"parserpower": "The name of the extension's entry in Special:SpecialPages",
+	"parserpower": "ParserPower",
 	"parserpower-desc": "A collection of extended parser functions for MediaWiki, particularly including functions for dealing with lists of values separated by a dynamically-specified delimiter.",
 	"parserpower-error": "$1 error: $2",
 	"parserpower-error-invalid-argument-number": "The number of given formatter arguments must be divisible by \"$1\".",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,3 +1,3 @@
 {
-	"name": "sbruck"
+	"parserpower": "{{name}}"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,3 +1,11 @@
 {
-	"parserpower": "{{name}}"
+	"parserpower": "{{name}}",
+	"parserpower-desc": "{{desc|name=ParserPower|url=https://www.mediawiki.org/wiki/Extension:ParserPower}}",
+	"parserpower-error": "Used when an error message is included.\n\nParameters:\n* $1 - source parser function name\n* $2 - error message",
+	"parserpower-error-invalid-argument-number": "An error message.\n\nParameters:\n$1 - number of parameters per template call",
+	"parserpower-error-invalid-integer": "An error message.",
+	"parserpower-error-missing-parameter": "An error message.\n\nParameters:\n$1 - a parameter name",
+	"parserpower-error-no-arguments": "An error message.",
+	"parserpower-duplicate-args-category": "{{tracking category name}}\nTracking category for pages using duplicate arguments in ParserPower functions",
+	"parserpower-duplicate-args-category-desc": "Description on [[Special:TrackingCategories]] for the {{msg-mw|parserpower-duplicate-args-category}} tracking category."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,4 +1,12 @@
 {
+	"@metadata" : {
+		"authors" : [
+			"OOeyes",
+			"Hydra Wiki Platform Team",
+			"wiki.gg development team",
+			"Derugon"
+		]
+	},
 	"parserpower": "{{name}}",
 	"parserpower-desc": "{{desc|name=ParserPower|url=https://www.mediawiki.org/wiki/Extension:ParserPower}}",
 	"parserpower-error": "Used when an error message is included.\n\nParameters:\n* $1 - source parser function name\n* $2 - error message",


### PR DESCRIPTION
Some changes about system message declarations:

- Update `@metadata` of `i18n` files.
- Fix (and register from `extension.json`) the `parserpower` extension name message.
- Register the `parserpower-duplicate-args-category` tracking category message from `extension.json`, and add a description message to it.
- Add basic documentation to all messages (in `i18n/qqq.json`).