### PR TITLE
refactor: Reuse `execute()` from `#listunique` with `#lstuniq`

### DIFF
--- a/src/Function/List/ListFunction.php
+++ b/src/Function/List/ListFunction.php
@@ -49,6 +49,21 @@ abstract class ListFunction extends ParserFunctionBase {
 	private static ?array $paramSpec;
 
 	/**
+	 * @var ?array Wikitext formatter for case sensitivity options.
+	 */
+	private static ?BoolFormatter $csFormatter;
+
+	/**
+	 * Get a wikitext formatter to decode case sensitivity options.
+	 *
+	 * @return BoolFormatter A wikitext-to-bool formatter.
+	 */
+	protected function getCSFormatter(): BoolFormatter {
+		self::$csFormatter ??= new BoolFormatter( 'cs', 'ncs' );
+		return self::$csFormatter;
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public function getParamSpec(): array {
@@ -57,7 +72,7 @@ abstract class ListFunction extends ParserFunctionBase {
 				'unescape' => true
 			],
 			'csoption' => [
-				'formatter' => new BoolFormatter( 'cs', 'ncs' )
+				'formatter' => $this->getCSFormatter()
 			],
 			'default' => [
 				'unescape' => true

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -4,12 +4,6 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
-use MediaWiki\Extension\ParserPower\ListUtils;
-use MediaWiki\Extension\ParserPower\Parameters;
-use MediaWiki\Extension\ParserPower\ParserPower;
-use MediaWiki\Parser\Parser;
-use MediaWiki\Parser\PPFrame;
-
 /**
  * Parser function for removing non-unique list values from an identity pattern (#lstuniq).
  */
@@ -38,29 +32,10 @@ final class LstUniqFunction extends ListUniqueFunction {
 			0 => 'list',
 			1 => 'insep',
 			2 => 'outsep',
-			3 => 'csoption'
+			3 => [
+				'alias' => 'uniquecs',
+				'formatter' => $this->getCSFormatter()
+			]
 		];
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function execute( Parser $parser, PPFrame $frame, Parameters $params ): string {
-		$inList = $params->get( 'list' );
-		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$values = ListUtils::explode( $inSep, $inList );
-
-		if ( count( $values ) === 0 ) {
-			return '';
-		}
-
-		$csOption = $params->get( 'csoption' );
-		$values = $this->reduceToUniqueValues( $values, $csOption );
-
-		$outSep = count( $values ) > 1 ? $params->get( 'outsep' ) : '';
-		$outList = ListUtils::implode( $values, $outSep );
-
-		return ParserPower::evaluateUnescaped( $parser, $frame, $outList );
 	}
 }


### PR DESCRIPTION
Since #57 makes `#lstuniq` share the same behavior as `#listunique`, this PR makes `#lstuniq` inherit its `execute()` from `#listunique`.