### PR TITLE
feat: Add a tracking category for pages with invalid function parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Add new entries to the top of the 1.x.x-NEXT section.
 ## Versions
 
 ### 1.x.x-NEXT (YYYY-MM-DD)
+* Added `parserpower-invalid-args-category` system message. It defines a tracking category added to pages using ParserPower parser functions with an invalid parameter, either numbered or named.
 * …
 
 ### 1.7.1 (2025-06-27)

--- a/extension.json
+++ b/extension.json
@@ -20,7 +20,8 @@
 		}
 	},
 	"TrackingCategories": [
-		"parserpower-duplicate-args-category"
+		"parserpower-duplicate-args-category",
+		"parserpower-invalid-args-category"
 	],
 	"MessagesDirs": {
 		"ParserPower": [

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -15,5 +15,7 @@
 	"parserpower-error-missing-parameter": "The parameter \"$1\" is required.",
 	"parserpower-error-no-arguments": "No formatter arguments were given.",
 	"parserpower-duplicate-args-category": "Pages using duplicate arguments in ParserPower functions",
-	"parserpower-duplicate-args-category-desc": "The page contains ParserPower function calls that use duplicates of arguments."
+	"parserpower-duplicate-args-category-desc": "The page contains ParserPower function calls that use duplicates of arguments.",
+	"parserpower-invalid-args-category": "Pages using invalid arguments in ParserPower functions",
+	"parserpower-invalid-args-category-desc": "The page contains ParserPower function calls that use invalid arguments."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -15,5 +15,7 @@
 	"parserpower-error-missing-parameter": "An error message.\n\nParameters:\n$1 - a parameter name",
 	"parserpower-error-no-arguments": "An error message.",
 	"parserpower-duplicate-args-category": "{{tracking category name}}\nTracking category for pages using duplicate arguments in ParserPower functions",
-	"parserpower-duplicate-args-category-desc": "Description on [[Special:TrackingCategories]] for the {{msg-mw|parserpower-duplicate-args-category}} tracking category."
+	"parserpower-duplicate-args-category-desc": "Description on [[Special:TrackingCategories]] for the {{msg-mw|parserpower-duplicate-args-category}} tracking category.",
+	"parserpower-invalid-args-category": "{{tracking category name}}\nTracking category for pages using invalid arguments in ParserPower functions",
+	"parserpower-invalid-args-category-desc": "Description on [[Special:TrackingCategories]] for the {{msg-mw|parserpower-invalid-args-category}} tracking category."
 }

--- a/src/Function/List/ListFilterFunction.php
+++ b/src/Function/List/ListFilterFunction.php
@@ -9,6 +9,7 @@ use MediaWiki\Extension\ParserPower\Operation\ListInclusionOperation;
 use MediaWiki\Extension\ParserPower\Operation\PatternOperation;
 use MediaWiki\Extension\ParserPower\Operation\TemplateOperation;
 use MediaWiki\Extension\ParserPower\Operation\WikitextOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
@@ -29,8 +30,8 @@ class ListFilterFunction extends ListFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return true;
+	public function getParserFlags(): int {
+		return ParameterParser::ALLOWS_NAMED;
 	}
 
 	/**

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -9,6 +9,7 @@ use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\Operation\PatternOperation;
 use MediaWiki\Extension\ParserPower\Operation\TemplateOperation;
 use MediaWiki\Extension\ParserPower\Operation\WikitextOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
@@ -29,8 +30,8 @@ class ListMapFunction extends ListFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return true;
+	public function getParserFlags(): int {
+		return ParameterParser::ALLOWS_NAMED;
 	}
 
 	/**

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -10,6 +10,7 @@ use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\Operation\PatternOperation;
 use MediaWiki\Extension\ParserPower\Operation\TemplateOperation;
 use MediaWiki\Extension\ParserPower\Operation\WikitextOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
@@ -40,8 +41,8 @@ class ListMergeFunction extends ListFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return true;
+	public function getParserFlags(): int {
+		return ParameterParser::ALLOWS_NAMED;
 	}
 
 	/**

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -9,6 +9,7 @@ use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\Operation\PatternOperation;
 use MediaWiki\Extension\ParserPower\Operation\TemplateOperation;
 use MediaWiki\Extension\ParserPower\Operation\WikitextOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
@@ -29,8 +30,8 @@ class ListSortFunction extends ListFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return true;
+	public function getParserFlags(): int {
+		return ParameterParser::ALLOWS_NAMED;
 	}
 
 	/**

--- a/src/Function/List/ListUniqueFunction.php
+++ b/src/Function/List/ListUniqueFunction.php
@@ -8,6 +8,7 @@ use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\Operation\PatternOperation;
 use MediaWiki\Extension\ParserPower\Operation\TemplateOperation;
 use MediaWiki\Extension\ParserPower\Operation\WikitextOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Parser\Parser;
@@ -28,8 +29,8 @@ class ListUniqueFunction extends ListFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return true;
+	public function getParserFlags(): int {
+		return ParameterParser::ALLOWS_NAMED;
 	}
 
 	/**

--- a/src/Function/List/LstCntUniqFunction.php
+++ b/src/Function/List/LstCntUniqFunction.php
@@ -24,8 +24,8 @@ final class LstCntUniqFunction extends ListUniqueFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -26,8 +26,8 @@ final class LstFltrFunction extends ListFilterFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -34,8 +34,8 @@ final class LstMapFunction extends ListMapFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -19,8 +19,8 @@ final class LstMapTempFunction extends ListMapFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -26,8 +26,8 @@ final class LstRmFunction extends ListFilterFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -19,8 +19,8 @@ final class LstSrtFunction extends ListSortFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -25,8 +25,8 @@ final class LstUniqFunction extends ListUniqueFunction {
 	/**
 	 * @inheritDoc
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/OrFunction.php
+++ b/src/Function/OrFunction.php
@@ -23,7 +23,7 @@ final class OrFunction extends ParserFunctionBase {
 	/**
 	 * @inheritDoc
 	 */
-	public function getDefaultSpec(): array {
+	public function getDefaultSpec(): ?array {
 		return [];
 	}
 

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -46,10 +46,10 @@ abstract class ParserFunctionBase implements ParserFunction {
 	/**
 	 * Get the parsing and post-processing options to use with unknown parameters.
 	 *
-	 * @return array A parameter specification.
+	 * @return ?array A parameter specification if unknown parameters are allowed.
 	 */
-	public function getDefaultSpec(): array {
-		return [];
+	public function getDefaultSpec(): ?array {
+		return null;
 	}
 
 	/**

--- a/src/Function/ParserFunctionBase.php
+++ b/src/Function/ParserFunctionBase.php
@@ -17,21 +17,16 @@ abstract class ParserFunctionBase implements ParserFunction {
 	private readonly ParameterParser $paramParser;
 
 	public function __construct() {
-		$paramFlags = 0;
-		if ( $this->allowsNamedParams() ) {
-			$paramFlags |= ParameterParser::ALLOWS_NAMED;
-		}
-
-		$this->paramParser = new ParameterParser( $this->getParamSpec(), $this->getDefaultSpec(), $paramFlags );
+		$this->paramParser = new ParameterParser( $this->getParamSpec(), $this->getDefaultSpec(), $this->getParserFlags() );
 	}
 
 	/**
-	 * Whether named parameters are recognized, along with numbered parameters.
+	 * Get the set of flags to use with the parameter parser.
 	 *
-	 * @return bool
+	 * @return int The set of ParameterParser flags.
 	 */
-	public function allowsNamedParams(): bool {
-		return false;
+	public function getParserFlags(): int {
+		return 0;
 	}
 
 	/**

--- a/src/Function/UeOrFunction.php
+++ b/src/Function/UeOrFunction.php
@@ -24,7 +24,7 @@ final class UeOrFunction extends ParserFunctionBase {
 	/**
 	 * @inheritDoc
 	 */
-	public function getDefaultSpec(): array {
+	public function getDefaultSpec(): ?array {
 		return [];
 	}
 

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -6,6 +6,7 @@ namespace MediaWiki\Extension\ParserPower;
 
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
+use MediaWiki\Parser\PPNode;
 
 /**
  * Parameter parser for parser functions.
@@ -22,6 +23,11 @@ final class ParameterParser {
 	 * Flag for whether named arguments are allowed, and should be split from numbered arguments.
 	 */
 	public const ALLOWS_NAMED = 1;
+	/**
+	 * Flag for tracking parameter values that contain an = at the root level, that may be confused as a parameter key.
+	 * May be used for migration purpose before enabling ALLOWS_NAMED.
+	 */
+	public const TRACKS_NAMED_VALUES = 2;
 
 	/**
 	 * @param array $paramOptions Parsing and post-processing options for all parameters.
@@ -33,6 +39,26 @@ final class ParameterParser {
 		private ?array $defaultOptions = null,
 		private int $flags = 0
 	) {
+	}
+
+	/**
+	 * Split a parameter key from its value.
+	 *
+	 * @param string|PPNode $param Parameter to split.
+	 * @return array Pair with the parameter key (if named) and value.
+	 */
+	private function splitKeyValue( string|PPNode $param ): array {
+		if ( is_string( $param ) ) {
+			$pair = explode( '=', $param, 2 );
+			$key = isset( $pair[1] ) ? array_shift( $pair ) : null;
+			$value = $pair[0];
+		} else {
+			$bits = $param->splitArg();
+			$key = $bits['index'] === '' ? $bits['name'] : null;
+			$value = $bits['value'];
+		}
+
+		return [ $key, $value ];
 	}
 
 	/**
@@ -50,15 +76,7 @@ final class ParameterParser {
 		foreach ( $rawParams as $rawParam ) {
 			// Split key from value
 			if ( $this->flags & self::ALLOWS_NAMED ) {
-				if ( is_string( $rawParam ) ) {
-					$pair = explode( '=', $rawParam, 2 );
-					$key = isset( $pair[1] ) ? array_shift( $pair ) : null;
-					$value = $pair[0];
-				} else {
-					$bits = $rawParam->splitArg();
-					$key = $bits['index'] === '' ? $bits['name'] : null;
-					$value = $bits['value'];
-				}
+				[ $key, $value ] = $this->splitKeyValue( $rawParam );
 			} else {
 				$key = null;
 				$value = $rawParam;
@@ -78,6 +96,18 @@ final class ParameterParser {
 			} else {
 				$parser->addTrackingCategory( 'parserpower-invalid-args-category' );
 				continue;
+			}
+
+			if ( $key === null && $this->flags & self::TRACKS_NAMED_VALUES ) {
+				try {
+					[ $subKey, ] = $this->splitKeyValue( $value );
+				} catch ( InvalidArgumentException ) {
+					// Not a parameter, probably not an issue.
+					$subKey = null;
+				}
+				if ( $subKey !== null ) {
+					$parser->addTrackingCategory( 'parserpower-invalid-args-category' );
+				}
 			}
 
 			// Resolve aliases

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -25,12 +25,12 @@ final class ParameterParser {
 
 	/**
 	 * @param array $paramOptions Parsing and post-processing options for all parameters.
-	 * @param array $defaultOptions Parsing and post-processing options for unknown parameters.
+	 * @param ?array $defaultOptions Parsing and post-processing options for unknown parameters if allowed.
 	 * @param int $flags Parameter parser flags.
 	 */
 	public function __construct(
 		private array $paramOptions = [],
-		private array $defaultOptions = [],
+		private ?array $defaultOptions = null,
 		private int $flags = 0
 	) {
 	}
@@ -71,8 +71,16 @@ final class ParameterParser {
 				$key = $numberedCount++;
 			}
 
+			if ( isset( $this->paramOptions[$key] ) ) {
+				$options = $this->paramOptions[$key];
+			} elseif ( $this->defaultOptions !== null ) {
+				$options = $this->defaultOptions;
+			} else {
+				$parser->addTrackingCategory( 'parserpower-invalid-args-category' );
+				continue;
+			}
+
 			// Resolve aliases
-			$options = $this->paramOptions[$key] ?? $this->defaultOptions;
 			if ( is_string( $options ) ) {
 				$key = $options;
 				$options = $this->paramOptions[$key];


### PR DESCRIPTION
Add a tracking categoryto pages using ParserPower parser functions, when a parameter name (or number) is not recognized by the parser function.

Using an additional `TRACKS_NAMED_VALUES` flag of `ParameterParser`, parser functions can check for invalid keys within numbered parameters when they do not recognize named parameters. This would allow tracking breakage on parser functions migration:
1. Assuming `$paramParserFlags = 0` is initially used to only recognize numbered parameters,
2. Use `$paramParserFlags = TRACKS_NAMED_VALUES` to still only recognize numbered parameters, but check for invalid named ones, then
3. Use `$paramParserFlags = ALLOWS_NAMED` to recognize both numbered and named parameters, and check for invalid ones.