### PR TITLE
feat: Add named parameters to shortcut functions

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -54,7 +54,12 @@
 	"config_prefix": "wgParserPower",
 	"config": {
 		"LstmapExpansionCompat": {
+			"description": "Use true to expand token and pattern variables only after token replacements in {{#lstmap}}. Use false to expand variables the same way as {{#listmap}}.",
 			"value": false
+		},
+		"LstFunctionNamedExpansionCompat": {
+			"description": "Use 'old' to only allow numbered parameters in {{#lstmap}}, {{#lstmaptemp}}, {{#lstsrt}}, and {{#lstuniq}}. Use 'tracking-old' to also track parameters that may be confused as named parameters. Use 'new' to allow both numbered and named parameters.",
+			"value": "old"
 		}
 	},
 	"manifest_version": 2

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -34,43 +34,21 @@ final class LstFltrFunction extends ListFilterFunction {
 	 * @inheritDoc
 	 */
 	public function getParamSpec(): array {
-		return [
+		$paramSpec = [
 			...parent::getParamSpec(),
 			0 => 'keep',
 			1 => 'keepsep',
 			2 => 'list',
 			3 => 'insep',
 			4 => 'outsep',
-			5 => 'csoption'
+			5 => [
+				'alias' => 'keepcs',
+				'formatter' => $this->getCSFormatter()
+			]
 		];
-	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function execute( Parser $parser, PPFrame $frame, Parameters $params ): string {
-		$inList = $params->get( 'list' );
-		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$inValues = ListUtils::explode( $inSep, $inList );
+		$paramSpec['pattern']['default'] = 'remove';
 
-		if ( empty( $inValues ) ) {
-			return '';
-		}
-
-		$values = $params->get( 'keep' );
-		$valueSep = $params->get( 'keepsep' );
-		$csOption = $params->get( 'csoption' );
-
-		if ( $valueSep !== '' ) {
-			$values = ListUtils::explode( $valueSep, $values );
-		} else {
-			$values = [ ParserPower::unescape( $values ) ];
-		}
-
-		$operation = new ListInclusionOperation( $values, '', 'remove', $csOption );
-		$outValues = $this->filterList( $operation, $inValues );
-
-		return ParserPower::evaluateUnescaped( $parser, $frame, $this->implodeOutList( $params, $outValues ) );
+		return $paramSpec;
 	}
 }

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -6,8 +6,10 @@ namespace MediaWiki\Extension\ParserPower\Function\List;
 
 use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\Operation\ListInclusionOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParserPowerConfig;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -15,6 +17,19 @@ use MediaWiki\Parser\PPFrame;
  * Parser function for filtering list values from an inclusion list (#lstfltr).
  */
 final class LstFltrFunction extends ListFilterFunction {
+
+	/**
+	 * @var bool Whether named parameters are allowed, and should be split from numbered arguments.
+	 */
+	private string $legacyNamedExpansion;
+
+	/**
+	 * @param ParserPowerConfig $config
+	 */
+	public function __construct( ParserPowerConfig $config ) {
+		$this->legacyNamedExpansion = $config->get( 'LstFunctionNamedExpansionCompat' );
+		parent::__construct();
+	}
 
 	/**
 	 * @inheritDoc
@@ -27,7 +42,13 @@ final class LstFltrFunction extends ListFilterFunction {
 	 * @inheritDoc
 	 */
 	public function getParserFlags(): int {
-		return 0;
+		if ( $this->legacyNamedExpansion === 'old' ) {
+			return 0;
+		} elseif ( $this->legacyNamedExpansion === 'tracking-old' ) {
+			return ParameterParser::TRACKS_NAMED_VALUES;
+		} else {
+			return ParameterParser::ALLOWS_NAMED;
+		}
 	}
 
 	/**

--- a/src/Function/List/LstFltrFunction.php
+++ b/src/Function/List/LstFltrFunction.php
@@ -4,14 +4,8 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
-use MediaWiki\Extension\ParserPower\ListUtils;
-use MediaWiki\Extension\ParserPower\Operation\ListInclusionOperation;
 use MediaWiki\Extension\ParserPower\ParameterParser;
-use MediaWiki\Extension\ParserPower\Parameters;
-use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Extension\ParserPower\ParserPowerConfig;
-use MediaWiki\Parser\Parser;
-use MediaWiki\Parser\PPFrame;
 
 /**
  * Parser function for filtering list values from an inclusion list (#lstfltr).

--- a/src/Function/List/LstMapFunction.php
+++ b/src/Function/List/LstMapFunction.php
@@ -4,6 +4,7 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\ParserPowerConfig;
 
 /**
@@ -11,6 +12,10 @@ use MediaWiki\Extension\ParserPower\ParserPowerConfig;
  */
 final class LstMapFunction extends ListMapFunction {
 
+	/**
+	 * @var bool Whether named parameters are allowed, and should be split from numbered arguments.
+	 */
+	private string $legacyNamedExpansion;
 	/**
 	 * @var bool Whether patterns and tokens should be expanded after token replacements.
 	 */
@@ -20,6 +25,7 @@ final class LstMapFunction extends ListMapFunction {
 	 * @param ParserPowerConfig $config
 	 */
 	public function __construct( ParserPowerConfig $config ) {
+		$this->legacyNamedExpansion = $config->get( 'LstFunctionNamedExpansionCompat' );
 		$this->useLegacyExpansion = $config->get( 'LstmapExpansionCompat' );
 		parent::__construct();
 	}
@@ -35,7 +41,13 @@ final class LstMapFunction extends ListMapFunction {
 	 * @inheritDoc
 	 */
 	public function getParserFlags(): int {
-		return 0;
+		if ( $this->legacyNamedExpansion === 'old' ) {
+			return 0;
+		} elseif ( $this->legacyNamedExpansion === 'tracking-old' ) {
+			return ParameterParser::TRACKS_NAMED_VALUES;
+		} else {
+			return ParameterParser::ALLOWS_NAMED;
+		}
 	}
 
 	/**

--- a/src/Function/List/LstMapTempFunction.php
+++ b/src/Function/List/LstMapTempFunction.php
@@ -4,10 +4,26 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
+use MediaWiki\Extension\ParserPower\ParserPowerConfig;
+
 /**
  * Parser function for mapping list values from a template (#lstmaptemp).
  */
 final class LstMapTempFunction extends ListMapFunction {
+
+	/**
+	 * @var bool Whether named parameters are allowed, and should be split from numbered arguments.
+	 */
+	private string $legacyNamedExpansion;
+
+	/**
+	 * @param ParserPowerConfig $config
+	 */
+	public function __construct( ParserPowerConfig $config ) {
+		$this->legacyNamedExpansion = $config->get( 'LstFunctionNamedExpansionCompat' );
+		parent::__construct();
+	}
 
 	/**
 	 * @inheritDoc
@@ -20,7 +36,13 @@ final class LstMapTempFunction extends ListMapFunction {
 	 * @inheritDoc
 	 */
 	public function getParserFlags(): int {
-		return 0;
+		if ( $this->legacyNamedExpansion === 'old' ) {
+			return 0;
+		} elseif ( $this->legacyNamedExpansion === 'tracking-old' ) {
+			return ParameterParser::TRACKS_NAMED_VALUES;
+		} else {
+			return ParameterParser::ALLOWS_NAMED;
+		}
 	}
 
 	/**

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -4,14 +4,8 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
-use MediaWiki\Extension\ParserPower\ListUtils;
-use MediaWiki\Extension\ParserPower\Operation\ListInclusionOperation;
 use MediaWiki\Extension\ParserPower\ParameterParser;
-use MediaWiki\Extension\ParserPower\Parameters;
-use MediaWiki\Extension\ParserPower\ParserPower;
 use MediaWiki\Extension\ParserPower\ParserPowerConfig;
-use MediaWiki\Parser\Parser;
-use MediaWiki\Parser\PPFrame;
 
 /**
  * Parser function for filtering list values from an exclusion value (#lstrm).

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -34,34 +34,20 @@ final class LstRmFunction extends ListFilterFunction {
 	 * @inheritDoc
 	 */
 	public function getParamSpec(): array {
-		return [
+		$paramSpec = [
 			...parent::getParamSpec(),
-			0 => 'value',
+			0 => 'remove',
 			1 => 'list',
 			2 => 'insep',
 			3 => 'outsep',
-			4 => 'csoption'
+			4 => [
+				'alias' => 'removecs',
+				'formatter' => $this->getCSFormatter()
+			]
 		];
-	}
 
-	/**
-	 * @inheritDoc
-	 */
-	public function execute( Parser $parser, PPFrame $frame, Parameters $params ): string {
-		$inList = $params->get( 'list' );
-		$inSep = $inList !== '' ? $params->get( 'insep' ) : '';
-		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
-		$inValues = ListUtils::explode( $inSep, $inList );
+		$paramSpec['removesep']['default'] = '';
 
-		if ( empty( $inValues ) ) {
-			return '';
-		}
-
-		$value = $params->get( 'value' );
-		$csOption = $params->get( 'csoption' );
-		$operation = new ListInclusionOperation( [ $value ], 'remove', '', $csOption );
-		$outValues = $this->filterList( $operation, $inValues );
-
-		return ParserPower::evaluateUnescaped( $parser, $frame, $this->implodeOutList( $params, $outValues ) );
+		return $paramSpec;
 	}
 }

--- a/src/Function/List/LstRmFunction.php
+++ b/src/Function/List/LstRmFunction.php
@@ -6,8 +6,10 @@ namespace MediaWiki\Extension\ParserPower\Function\List;
 
 use MediaWiki\Extension\ParserPower\ListUtils;
 use MediaWiki\Extension\ParserPower\Operation\ListInclusionOperation;
+use MediaWiki\Extension\ParserPower\ParameterParser;
 use MediaWiki\Extension\ParserPower\Parameters;
 use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\ParserPower\ParserPowerConfig;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -15,6 +17,19 @@ use MediaWiki\Parser\PPFrame;
  * Parser function for filtering list values from an exclusion value (#lstrm).
  */
 final class LstRmFunction extends ListFilterFunction {
+
+	/**
+	 * @var bool Whether named parameters are allowed, and should be split from numbered arguments.
+	 */
+	private string $legacyNamedExpansion;
+
+	/**
+	 * @param ParserPowerConfig $config
+	 */
+	public function __construct( ParserPowerConfig $config ) {
+		$this->legacyNamedExpansion = $config->get( 'LstFunctionNamedExpansionCompat' );
+		parent::__construct();
+	}
 
 	/**
 	 * @inheritDoc
@@ -27,7 +42,13 @@ final class LstRmFunction extends ListFilterFunction {
 	 * @inheritDoc
 	 */
 	public function getParserFlags(): int {
-		return 0;
+		if ( $this->legacyNamedExpansion === 'old' ) {
+			return 0;
+		} elseif ( $this->legacyNamedExpansion === 'tracking-old' ) {
+			return ParameterParser::TRACKS_NAMED_VALUES;
+		} else {
+			return ParameterParser::ALLOWS_NAMED;
+		}
 	}
 
 	/**

--- a/src/Function/List/LstSrtFunction.php
+++ b/src/Function/List/LstSrtFunction.php
@@ -4,10 +4,26 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
+use MediaWiki\Extension\ParserPower\ParserPowerConfig;
+
 /**
  * Parser function for sorting list values from an identity pattern (#lstsrt).
  */
 final class LstSrtFunction extends ListSortFunction {
+
+	/**
+	 * @var bool Whether named parameters are allowed, and should be split from numbered arguments.
+	 */
+	private string $legacyNamedExpansion;
+
+	/**
+	 * @param ParserPowerConfig $config
+	 */
+	public function __construct( ParserPowerConfig $config ) {
+		$this->legacyNamedExpansion = $config->get( 'LstFunctionNamedExpansionCompat' );
+		parent::__construct();
+	}
 
 	/**
 	 * @inheritDoc
@@ -20,7 +36,13 @@ final class LstSrtFunction extends ListSortFunction {
 	 * @inheritDoc
 	 */
 	public function getParserFlags(): int {
-		return 0;
+		if ( $this->legacyNamedExpansion === 'old' ) {
+			return 0;
+		} elseif ( $this->legacyNamedExpansion === 'tracking-old' ) {
+			return ParameterParser::TRACKS_NAMED_VALUES;
+		} else {
+			return ParameterParser::ALLOWS_NAMED;
+		}
 	}
 
 	/**

--- a/src/Function/List/LstUniqFunction.php
+++ b/src/Function/List/LstUniqFunction.php
@@ -4,10 +4,26 @@
 
 namespace MediaWiki\Extension\ParserPower\Function\List;
 
+use MediaWiki\Extension\ParserPower\ParameterParser;
+use MediaWiki\Extension\ParserPower\ParserPowerConfig;
+
 /**
  * Parser function for removing non-unique list values from an identity pattern (#lstuniq).
  */
 final class LstUniqFunction extends ListUniqueFunction {
+
+	/**
+	 * @var bool Whether named parameters are allowed, and should be split from numbered arguments.
+	 */
+	private string $legacyNamedExpansion;
+
+	/**
+	 * @param ParserPowerConfig $config
+	 */
+	public function __construct( ParserPowerConfig $config ) {
+		$this->legacyNamedExpansion = $config->get( 'LstFunctionNamedExpansionCompat' );
+		parent::__construct();
+	}
 
 	/**
 	 * @inheritDoc
@@ -20,7 +36,13 @@ final class LstUniqFunction extends ListUniqueFunction {
 	 * @inheritDoc
 	 */
 	public function getParserFlags(): int {
-		return 0;
+		if ( $this->legacyNamedExpansion === 'old' ) {
+			return 0;
+		} elseif ( $this->legacyNamedExpansion === 'tracking-old' ) {
+			return ParameterParser::TRACKS_NAMED_VALUES;
+		} else {
+			return ParameterParser::ALLOWS_NAMED;
+		}
 	}
 
 	/**

--- a/src/ParameterParser.php
+++ b/src/ParameterParser.php
@@ -99,7 +99,7 @@ final class ParameterParser {
 				continue;
 			}
 
-			if ( $key === null && $this->flags & self::TRACKS_NAMED_VALUES ) {
+			if ( is_int( $key ) && $this->flags & self::TRACKS_NAMED_VALUES ) {
 				try {
 					[ $subKey, ] = $this->splitKeyValue( $value );
 				} catch ( InvalidArgumentException ) {

--- a/src/ParserVariableRegistry.php
+++ b/src/ParserVariableRegistry.php
@@ -105,7 +105,10 @@ final class ParserVariableRegistry {
 		LstCntFunction::class,
 		LstCntUniqFunction::class,
 		LstElemFunction::class,
-		LstFltrFunction::class,
+		[
+			'class' => LstFltrFunction::class,
+			'services' => [ 'ParserPower.Config' ]
+		],
 		LstFndFunction::class,
 		LstIndFunction::class,
 		LstJoinFunction::class,
@@ -113,13 +116,25 @@ final class ParserVariableRegistry {
 			'class' => LstMapFunction::class,
 			'services' => [ 'ParserPower.Config' ]
 		],
-		LstMapTempFunction::class,
+		[
+			'class' => LstMapTempFunction::class,
+			'services' => [ 'ParserPower.Config' ]
+		],
 		LstPrepFunction::class,
-		LstRmFunction::class,
+		[
+			'class' => LstRmFunction::class,
+			'services' => [ 'ParserPower.Config' ]
+		],
 		LstSepFunction::class,
-		LstSrtFunction::class,
+		[
+			'class' => LstSrtFunction::class,
+			'services' => [ 'ParserPower.Config' ]
+		],
 		LstSubFunction::class,
-		LstUniqFunction::class
+		[
+			'class' => LstUniqFunction::class,
+			'services' => [ 'ParserPower.Config' ]
+		]
 	];
 
 	public function __construct( private ObjectFactory $objectFactory ) {


### PR DESCRIPTION
Fixes #49, for which this PR provides the (supposedly) last batch of changes.

## Proposed changes (part 1)

Make `#lstfltr` and `#lstrm` inherit their behavior from `#listfilter`.

However, both of these functions do not work exactly the same way as `#listfilter`. To prevent breakage, the default values of some parameters are made different from `#listfilter`. These behaviors may be made consistent in the future, but this is not covered in this PR:

- `#lstfltr` removes all values if `|keep=` is empty, while `#listfilter` keeps all values, which is circumvented by using `|pattern=remove` (for `#lstfltr` only) unless `pattern` is explicitely specified.
- `#lstrm` has no `|removesep=` by default, while `#listfilter` make it default to `,`, which is circumvented by using `|removesep=` (for `#lstrm` only) unless `removesep` is explicitely specified.

## Proposed changes (part 2)

Add a `LstFunctionNamedExpansionCompat` configuration variable to handle named parameters in `#lstfltr`, `#lstmap`, `#lstmaptemp`, `#lstrm`, `#lstsrt`, and `#lstuniq`, in 3 stages:

1. `LstFunctionNamedExpansionCompat = "old"` to only allow numbered parameters,
2. `LstFunctionNamedExpansionCompat = "tracking-old"` to also track parameters that may be confused as named parameters, then
3. `LstFunctionNamedExpansionCompat = "new"` to allow both numbered and named parameters.

In this PR, the configuration variable is set to `old` by default.