### PR TITLE
feat: Add Lua functions for escaping/unescaping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Add new entries to the top of the 1.x.x-NEXT section.
 ## Versions
 
 ### 1.x.x-NEXT (YYYY-MM-DD)
+* Added a `mw.ext.ParserPower.string` Lua library. It contains utility functions for adding (`escape`) or removing (`unescape`) escape sequences from text.
 * …
 
 ### 1.8.0 (2025-07-21)

--- a/extension.json
+++ b/extension.json
@@ -43,10 +43,14 @@
 			"services": [
 				"ParserPower.ParserVariableRegistry"
 			]
+		},
+		"Scribunto": {
+			"class": "MediaWiki\\Extension\\ParserPower\\Hooks\\ScribuntoHooks"
 		}
 	},
 	"Hooks": {
-		"ParserFirstCallInit": "FunctionRegistration"
+		"ParserFirstCallInit": "FunctionRegistration",
+		"ScribuntoExternalLibraries": "Scribunto"
 	},
 	"ConfigRegistry": {
 		"ParserPower": "MediaWiki\\Extension\\ParserPower\\ParserPowerConfig::newInstance"

--- a/src/Hooks/FunctionRegistrationHooks.php
+++ b/src/Hooks/FunctionRegistrationHooks.php
@@ -7,6 +7,9 @@ namespace MediaWiki\Extension\ParserPower\Hooks;
 use MediaWiki\Extension\ParserPower\ParserVariableRegistry;
 use MediaWiki\Parser\Parser;
 
+/**
+ * Hook handler for registering functions/tags with the legacy parser.
+ */
 final class FunctionRegistrationHooks implements
 	\MediaWiki\Hook\ParserFirstCallInitHook
 {

--- a/src/Hooks/ScribuntoHooks.php
+++ b/src/Hooks/ScribuntoHooks.php
@@ -1,0 +1,27 @@
+<?php
+
+/** @license GPL-2.0-or-later */
+
+namespace MediaWiki\Extension\ParserPower\Hooks;
+
+use MediaWiki\Extension\ParserPower\Scribunto\StringLuaLibrary;
+use MediaWiki\Extension\Scribunto\Hooks\ScribuntoExternalLibrariesHook;
+
+/**
+ * Hook handler for registering Lua libraries with Scribunto.
+ */
+final class ScribuntoHooks implements ScribuntoExternalLibrariesHook {
+
+	/**
+	 * Register mw.ext.ParserPower Lua libraries.
+	 *
+	 * @param string $engine
+	 * @param array &$extraLibraries
+	 * @return void
+	 */
+	public function onScribuntoExternalLibraries( string $engine, array &$extraLibraries ) {
+		if ( $engine === 'lua' ) {
+			$extraLibraries['mw.ext.ParserPower.string'] = StringLuaLibrary::class;
+		}
+	}
+}

--- a/src/Scribunto/StringLuaLibrary.php
+++ b/src/Scribunto/StringLuaLibrary.php
@@ -16,6 +16,31 @@ final class StringLuaLibrary extends LibraryBase {
 	 * @inheritDoc
 	 */
 	public function register() {
-		return $this->getEngine()->registerInterface( __DIR__ . '/lua/ParserPower.string.lua', [] );
+		$lib = [
+			'escape' => [ $this, 'escape' ],
+			'unescape' => [ $this, 'unescape' ]
+		];
+
+		return $this->getEngine()->registerInterface( __DIR__ . '/lua/ParserPower.string.lua', $lib );
+	}
+
+	/**
+	 * Replace all appropriate characters with escape sequences.
+	 *
+	 * @param string $text The text to escape.
+	 * @return array The escaped text.
+	 */
+	public function escape( string $text ): array {
+		return [ ParserPower::escape( $text ) ];
+	}
+
+	/**
+	 * Replace all escape sequences with the appropriate characters.
+	 *
+	 * @param string $text The text to unescape.
+	 * @return array The text with all escape sequences replaced.
+	 */
+	public function unescape( string $text ): array {
+		return [ ParserPower::unescape( $text ) ];
 	}
 }

--- a/src/Scribunto/StringLuaLibrary.php
+++ b/src/Scribunto/StringLuaLibrary.php
@@ -1,0 +1,21 @@
+<?php
+
+/** @license GPL-2.0-or-later */
+
+namespace MediaWiki\Extension\ParserPower\Scribunto;
+
+use MediaWiki\Extension\ParserPower\ParserPower;
+use MediaWiki\Extension\Scribunto\Engines\LuaCommon\LibraryBase;
+
+/**
+ * Lua library with string manipulation functions (mw.ext.ParserPower.string).
+ */
+final class StringLuaLibrary extends LibraryBase {
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register() {
+		return $this->getEngine()->registerInterface( __DIR__ . '/lua/ParserPower.string.lua', [] );
+	}
+}

--- a/src/Scribunto/lua/ParserPower.string.lua
+++ b/src/Scribunto/lua/ParserPower.string.lua
@@ -16,4 +16,14 @@ function ParserPowerString.setupInterface( options )
 	package.loaded['mw.ext.ParserPower.string'] = ParserPowerString
 end
 
+function ParserPowerString.escape( text )
+	libraryUtil.checkType( 'escape', 1, text, 'string' )
+	return php.escape( text )
+end
+
+function ParserPowerString.unescape( text )
+	libraryUtil.checkType( 'unescape', 1, text, 'string' )
+	return php.unescape( text )
+end
+
 return ParserPowerString

--- a/src/Scribunto/lua/ParserPower.string.lua
+++ b/src/Scribunto/lua/ParserPower.string.lua
@@ -1,0 +1,19 @@
+local libraryUtil = require( 'libraryUtil' )
+
+local ParserPowerString = {}
+local php
+
+function ParserPowerString.setupInterface( options )
+	ParserPowerString.setupInterface = nil
+	php = mw_interface
+	mw_interface = nil
+
+	mw = mw or {}
+	mw.ext = mw.ext or {}
+	mw.ext.ParserPower = mw.ext.ParserPower or {}
+	mw.ext.ParserPower.string = ParserPowerString
+
+	package.loaded['mw.ext.ParserPower.string'] = ParserPowerString
+end
+
+return ParserPowerString


### PR DESCRIPTION
## Proposed changes

Add a Lua library for ParserPower escape sequence manipulation (as `mw.ext.ParserPower.string`), with 2 functions:

- `escape( text )` that replaces all appropriate characters within `text` with escape sequences, and
- `unescape( text )` that replaces all escape sequences within `text` with their appropriate characters.

Both of these functions only do string replacement, and do not replace variables in any way, such that `unescape( '{\\{!}\\}' ) == '{{!}}'` and consequently `unescape( escape( x ) ) == x`.

## Why

ParserPower provides a set list manipulation functions, but some use cases can not be easily covered by these functions, such as parallel list computations (e.g. zipping 2 lists of values, sorting a list of values by a list of keys) or traversals (e.g. mapping a list with an accumulator).

Even if such functions were to be added in the future, writing Lua functions for a specific combination of chained list operations may still be preferred for performance or maintenance purposes.

However, if most list function behaviors can be reproduced easily in Lua using base and MediaWiki libraries, there is no easy way to reproduce token replacement in patterns. Let `replaceToken( value, token, pattern )`, it would need to:

1. Unescape `pattern` and `token`,
2. Replace occurrences of `token` with `value` within `pattern`, then
3. Evaluate variables within the output `pattern`.

We could use `#uesc`, but escaped variables would be evaluated before the token replacement:

```lua
function replaceToken( value, token, pattern )
	token   = frame:callParserFunction( '#uesc', token )
	pattern = frame:callParserFunction( '#uesc', pattern )
	pattern = pattern:gsub( token, value )
	return pattern
end
```

We could alternatively use `#uescnowiki`, but we would have to kill all kill markers, not only the `nowiki` ones:

```lua
function replaceToken( value, token, pattern )
	token   = mw.text.killMarkers( frame:callParserFunction( '#uescnowiki', token ) )
	pattern = mw.text.killMarkers( frame:callParserFunction( '#uescnowiki', pattern ) )
	pattern = pattern:gsub( token, value )
	return frame:preprocess( pattern )
end
```

A proper unescaping function would provide a way of easily controlling evaluation order with unescaping:

```lua
function replaceToken( value, token, pattern )
	token   = ParserPower.string.unescape( token )
	pattern = ParserPower.string.unescape( pattern )
	pattern = pattern:gsub( token, value )
	return frame:preprocess( pattern )
end
```

## Why `mw.ext.ParserPower.string`

Simply because it was the name River mentioned on discord when I shortly talked about it a few months ago, the base library also includes `mw.text`, so I could also propose `mw.ext.ParserPower.text` as an alternative name. The same goes for ParserPower casing (e.g. `mw.ext.parserpower`?).