### PR TITLE
fix: Prevent tokens from being replaced inside their substitution values

### DIFF
--- a/src/Function/TokenFunction.php
+++ b/src/Function/TokenFunction.php
@@ -36,7 +36,16 @@ final class TokenFunction extends ParserFunctionBase {
 	 * @inheritDoc
 	 */
 	public function execute( Parser $parser, PPFrame $frame, Parameters $params ): string {
-		$outValue = ParserPower::applyPattern( $params->get( 0 ), $params->get( 1 ), $params->get( 2 ) );
+		$inValue = $params->get( 0 );
+		$token = $params->get( 1 );
+		$pattern = $params->get( 2 );
+
+		if ( $pattern === '' ) {
+			$outValue = $inValue;
+		} else {
+			$outValue = str_replace( $token, $inValue, $pattern );
+		}
+
 		$outValue = $parser->preprocessToDom( $outValue, $frame->isTemplate() ? Parser::PTD_FOR_INCLUSION : 0 );
 		$outValue = ParserPower::expand( $frame, $outValue, ParserPower::UNESCAPE );
 

--- a/src/Function/TokenIfFunction.php
+++ b/src/Function/TokenIfFunction.php
@@ -42,7 +42,15 @@ final class TokenIfFunction extends ParserFunctionBase {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 3 ) );
 		}
 
-		$outValue = ParserPower::applyPattern( $inValue, $params->get( 1 ), $params->get( 2 ) );
+		$token = $params->get( 1 );
+		$pattern = $params->get( 2 );
+
+		if ( $pattern === '' ) {
+			$outValue = $inValue;
+		} else {
+			$outValue = str_replace( $token, $inValue, $pattern );
+		}
+
 		$outValue = $parser->preprocessToDom( $outValue, $frame->isTemplate() ? Parser::PTD_FOR_INCLUSION : 0 );
 		$outValue = ParserPower::expand( $frame, $outValue, ParserPower::UNESCAPE );
 

--- a/src/Operation/PatternOperation.php
+++ b/src/Operation/PatternOperation.php
@@ -39,11 +39,11 @@ final class PatternOperation implements WikitextOperation {
 		}
 
 		if ( $index !== null ) {
-			$result = ParserPower::applyPattern( (string)$index, $this->indexToken, $result );
+			$result = str_replace( $this->indexToken, (string)$index, $result );
 		}
 
 		foreach ( $this->tokens as $i => $token ) {
-			$result = ParserPower::applyPattern( $fields[$i] ?? '', $token, $result );
+			$result = str_replace( $token, $fields[$i] ?? '', $result );
 		}
 
 		$result = ParserPower::unescape( $result );

--- a/src/Operation/PatternOperation.php
+++ b/src/Operation/PatternOperation.php
@@ -33,19 +33,21 @@ final class PatternOperation implements WikitextOperation {
 	 * @inheritDoc
 	 */
 	public function apply( array $fields, ?int $index = null ): string {
-		$result = $this->pattern;
-		if ( $result === '' ) {
+		if ( $this->pattern === '' ) {
 			return $fields[0];
 		}
 
-		if ( $index !== null ) {
-			$result = str_replace( $this->indexToken, (string)$index, $result );
+		$repl = [];
+		if ( $this->indexToken !== '' && $index !== null ) {
+			$repl[$this->indexToken] = (string)$index;
 		}
-
 		foreach ( $this->tokens as $i => $token ) {
-			$result = str_replace( $token, $fields[$i] ?? '', $result );
+			if ( $token !== '' ) {
+				$repl[$token] = $fields[$i] ?? '';
+			}
 		}
 
+		$result = strtr( $this->pattern, $repl );
 		$result = ParserPower::unescape( $result );
 		return ParserPower::evaluateUnescaped( $this->parser, $this->frame, $result, ParserPower::WITH_ARGS );
 	}

--- a/src/ParserPower.php
+++ b/src/ParserPower.php
@@ -207,22 +207,6 @@ class ParserPower {
 	}
 
 	/**
-	 * Replaces the indicated token in the pattern with the input value.
-	 *
-	 * @param string $value The value to change into one or more template parameters.
-	 * @param string $token The token to replace.
-	 * @param string $pattern Pattern containing token to be replaced with the input value.
-	 * @return string The result of the token replacement within the pattern.
-	 */
-	public static function applyPattern( string $value, string $token, string $pattern ): string {
-		if ( $pattern === '' ) {
-			return $value;
-		} else {
-			return str_replace( $token, $value, $pattern );
-		}
-	}
-
-	/**
 	 * Create a ParserPower-specific message.
 	 *
 	 * @param string $key Message key.

--- a/tests/parser/listFunctionsTest.txt
+++ b/tests/parser/listFunctionsTest.txt
@@ -2313,3 +2313,12 @@ numeric desc: "66, 44, 33, 32, 11"
 "def"
 </p>
 !! end
+
+!! test
+{{#listmap}} tokens are not replaced in substitution values of other tokens
+!! wikitext
+"{{#listmap: list = @:x, y:$, x:z | fieldsep = : | token = $, @ | pattern = @:$ }}"
+!! html/php
+<p>"x:@, $:y, z:x"
+</p>
+!! end


### PR DESCRIPTION
## The issue

Let `{{swap kv}}` be a template that takes a `key: value` list as parameter, and returns this same list with keys and values swapped. Using the `#listmap:` parser function, it could be defined as:

```
{{#listmap:
 | list     = {{{1}}}
 | fieldsep = :
 | token    = $, @
 | pattern  = @: $
}}
```

However, using `{{swap kv | @:x, b:y, c:z }}` would yield `x: x, y: b, z: c` instead of `x: @, y: b, z: c`. This is because tokens are replaced in order. In the previous example, for the 1st list value:
1. We start with the initial pattern `@: $`,
2. `$` is replaced with `@`, yielding `@: @`, then
3. `@` is replaced with `x`, yielding `x: x`.

## Proposed changes

Use a single `strtr` to replace all tokens at once per iteration. This affects all list functions that may replace multiple tokens at once in a pattern: `#listfilter`, `#listunique`, `#listsort`, `#listmap`, and `#listmerge`.

## Breaking changes

1. Templates relying on the issue this PR is about,
2. Templates using (partially-)overlapping tokens, since `strtr` prioritizes larger tokens andthis PR consequently changes the token replacement order. 