### PR TITLE
perf: Evaluate list function parameters more lazily with sorting / duplicate stripping

### DIFF
--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -76,18 +76,19 @@ class ListMapFunction extends ListFunction {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
-		$template = $params->get( 'template' );
-		$fieldSep = $params->get( 'fieldsep' );
-
-		$sortMode = $params->get( 'sortmode' );
-		$sortOptions = $sortMode > 0 ? $params->get( 'sortoptions' ) : 0;
-		$sorter = new ListSorter( $sortOptions );
-
 		$duplicates = $count > 1 ? $params->get( 'duplicates' ) : 0;
 
 		if ( $duplicates & self::DUPLICATES_PRESTRIP ) {
 			$inValues = array_unique( $inValues );
+			$count = count( $inValues );
 		}
+
+		$sortMode = $count > 1 ? $params->get( 'sortmode' ) : 0;
+		$sortOptions = $sortMode > 0 ? $params->get( 'sortoptions' ) : 0;
+		$sorter = new ListSorter( $sortOptions );
+
+		$template = $params->get( 'template' );
+		$fieldSep = $params->get( 'fieldsep' );
 
 		if ( $template !== '' ) {
 			if ( $sortMode & self::SORTMODE_PRE ) {

--- a/src/Function/List/ListMapFunction.php
+++ b/src/Function/List/ListMapFunction.php
@@ -71,7 +71,8 @@ class ListMapFunction extends ListFunction {
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 
-		if ( empty( $inValues ) ) {
+		$count = count( $inValues );
+		if ( $count === 0 ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
@@ -82,7 +83,7 @@ class ListMapFunction extends ListFunction {
 		$sortOptions = $sortMode > 0 ? $params->get( 'sortoptions' ) : 0;
 		$sorter = new ListSorter( $sortOptions );
 
-		$duplicates = $params->get( 'duplicates' );
+		$duplicates = $count > 1 ? $params->get( 'duplicates' ) : 0;
 
 		if ( $duplicates & self::DUPLICATES_PRESTRIP ) {
 			$inValues = array_unique( $inValues );

--- a/src/Function/List/ListMergeFunction.php
+++ b/src/Function/List/ListMergeFunction.php
@@ -156,7 +156,8 @@ class ListMergeFunction extends ListFunction {
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$inValues = ListUtils::explode( $inSep, $inList );
 
-		if ( empty( $inValues ) ) {
+		$count = count( $inValues );
+		if ( $count === 0 ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
 		}
 
@@ -164,7 +165,7 @@ class ListMergeFunction extends ListFunction {
 		$mergeTemplate = $params->get( 'mergetemplate' );
 		$fieldSep = $params->get( 'fieldsep' );
 
-		$sortMode = $params->get( 'sortmode' );
+		$sortMode = $count > 1 ? $params->get( 'sortmode' ) : 0;
 		$sortOptions = $sortMode > 0 ? $params->get( 'sortoptions' ) : 0;
 		$sorter = new ListSorter( $sortOptions );
 

--- a/src/Function/List/ListSortFunction.php
+++ b/src/Function/List/ListSortFunction.php
@@ -81,18 +81,29 @@ class ListSortFunction extends ListFunction {
 		$inSep = $parser->getStripState()->unstripNoWiki( $inSep );
 		$values = ListUtils::explode( $inSep, $inList );
 
-		if ( empty( $values ) ) {
+		$count = count( $values );
+		if ( $count === 0 ) {
 			return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+		} elseif ( $count === 1 ) {
+			return ParserPower::evaluateUnescaped( $parser, $frame, $this->implodeOutList( $params, $values ) );
 		}
 
-		$template = $params->get( 'template' );
-		$subsort = $params->get( 'subsort' );
-		$subsortOptions = $subsort ? $params->get( 'subsortoptions' ) : null;
 		$duplicates = $params->get( 'duplicates' );
 
 		if ( $duplicates & self::DUPLICATES_STRIP ) {
 			$values = array_unique( $values );
+			$count = count( $values );
+			if ( $count === 0 ) {
+				return ParserPower::evaluateUnescaped( $parser, $frame, $params->get( 'default' ) );
+			} elseif ( $count === 1 ) {
+				return ParserPower::evaluateUnescaped( $parser, $frame, $this->implodeOutList( $params, $values ) );
+			}
 		}
+
+		$subsort = $params->get( 'subsort' );
+		$subsortOptions = $subsort ? $params->get( 'subsortoptions' ) : null;
+
+		$template = $params->get( 'template' );
 
 		if ( $template !== '' ) {
 			$fieldSep = $params->get( 'fieldsep' );


### PR DESCRIPTION
More laziness changes, related to #3.

## Proposed changes

Ensure list functions do not evaluate sorting / duplicate stripping parameters if the input list has only 1 value.

`#listmap`:
- Do not evaluate `duplicates` if the input list has only 1 value.
- Do not evaluate `sortmode`/`sortoptions` if the input list has only 1 value once duplicates have been stripped.

`#lstmap`/`#lstmaptemp`:
- Do not evaluate sort parameters (5 and 6 for `#lstmap`, 4 and 5 for `#lstmap`) if the input list has only 1 value.

`#listsort`:
- Stop the function execution if the input list has only 1 value either before or after duplicates have been stripped.

`#listmerge`:
- Do not evaluate `sortmode`/`sortoptions` if the input list has only 1 value.